### PR TITLE
Specify path to unclear prj.conf file

### DIFF
--- a/docs/guides/quickstart/6-flash-sample.md
+++ b/docs/guides/quickstart/6-flash-sample.md
@@ -44,7 +44,7 @@ cd ~/zephyrproject/modules/lib/golioth
 
 Zephyr uses [Kconfig](https://docs.zephyrproject.org/latest/guides/kconfig/index.html) to manage build settings at scale. Kconfig values can be set a number of ways but for this example we'll take a simple route by modifying `prj.conf`.
 
-Open `prj.conf` in your editor of choice and add these fields:
+Open `samples/hello/prj.conf` in your editor of choice and add these fields:
 
 ```
 CONFIG_ESP32_WIFI_SSID="YOUR_NETWORK_NAME"


### PR DESCRIPTION
This PR specifies where the `prj.conf` file is in the flashing step of the quickstart guide.