### PR TITLE
Fixed nrf sdk github link

### DIFF
--- a/docs/partials/install-nrf91-sdk.md
+++ b/docs/partials/install-nrf91-sdk.md
@@ -7,7 +7,7 @@ With `west` installed, grab the Device SDK:
 
 ```
 cd ~
-west init -m https://github.com/nrfconnect/sdk-nrf --mr v1.6-branch ~/zephyr-nrf
+west init -m https://github.com/nrfconnect/sdk-nrf --mr v1.7.1 ~/zephyr-nrf
 cd zephyr-nrf/
 west update
 west patch

--- a/docs/partials/install-nrf91-sdk.md
+++ b/docs/partials/install-nrf91-sdk.md
@@ -7,7 +7,7 @@ With `west` installed, grab the Device SDK:
 
 ```
 cd ~
-west init -m https://github.com/nrfconnect/sdk-nrf --mr v1.6.0main ~/zephyr-nrf
+west init -m https://github.com/nrfconnect/sdk-nrf --mr v1.6-branch ~/zephyr-nrf
 cd zephyr-nrf/
 west update
 west patch


### PR DESCRIPTION
I found this line failed when trying to setup the nrf SDK, when checking the source link it seems the branch structure has changed https://github.com/nrfconnect/sdk-nrf/tree/v1.6-branch 
amended accordingly 