### PR TITLE
Remove west patch step, update SDK install instructions

### DIFF
--- a/docs/hardware/4-nrf91/2-quickstart/1-overview.md
+++ b/docs/hardware/4-nrf91/2-quickstart/1-overview.md
@@ -1,6 +1,6 @@
 ---
 id: overview
-title: nRF91 Quickstart Overview
+title: nRF9160 Quickstart Overview
 slug: /hardware/nrf91/quickstart
 ---
 
@@ -8,8 +8,8 @@ slug: /hardware/nrf91/quickstart
 You must first follow the [Golioth Platform Quickstart](/getting-started) before attempting this guide.
 :::
 
-This work-through will demonstrate how to quickly connect an nRF91 based device to Golioth. The following devices are proven to work with Golioth:
-* Nordic nRF9160-DK
-* CircuitDojo nRF91-Feather
+This work-through will demonstrate how to quickly connect an nRF9160 based device to Golioth. The following devices are proven to work with Golioth:
+* [Nordic nRF9160-DK](/hardware/catalog/boards/quickstart/arm_nrf9160dk_nrf9160)
+* [CircuitDojo nRF91-Feather](/hardware/catalog/boards/quickstart/arm_circuitdojo_feather_nrf9160)
 
-See the [Hardware](/hardware) section for more devices that use the nRF91
+See the [Hardware Catalog](/hardware/catalog) search tool for more devices that use the nRF9160

--- a/docs/hardware/4-nrf91/2-quickstart/2-set-up-zephyr.md
+++ b/docs/hardware/4-nrf91/2-quickstart/2-set-up-zephyr.md
@@ -1,6 +1,6 @@
 ---
 id: set-up-zephyr
-title: Set up Zephyr for the nRF9160
+title: Set up Zephyr for nRF9160
 ---
 
 ### Zephyr Setup Overview
@@ -25,7 +25,7 @@ import InstallNRFSDK from '/docs/partials/install-nrf91-sdk.md'
 
 The nRF9160 is an ARM based device, so we will use the ARM toolchains (gcc, gdb, etc) included in the Zephyr SDK
 
-import InstallZephyrSDKtoolchain from '/docs/partials/install-zephyr-sdk-toolchain.md'
+import InstallZephyrSDKtoolchain from '/docs/partials/install-zephyr-sdk-toolchain.md'  
 
 <InstallZephyrSDKtoolchain/>
 
@@ -35,7 +35,7 @@ Your system is all set up and ready to start building & flashing with Zephyr. Ve
 
 ```
 cd ~/zephyr-nrf/zephyr
-west build -p auto -b  circuitdojo_feather_nrf9160_ns samples/basic/minimal
+west build -p auto -b  circuitdojo_feather_nrf9160ns samples/basic/minimal
 ```
 Alternatively, build for the nRF9160_DK with the following commands:
 

--- a/docs/hardware/4-nrf91/2-quickstart/2-set-up-zephyr.md
+++ b/docs/hardware/4-nrf91/2-quickstart/2-set-up-zephyr.md
@@ -3,6 +3,9 @@ id: set-up-zephyr
 title: Set up Zephyr for nRF9160
 ---
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
 ### Zephyr Setup Overview
 
 Golioth is implemented on IoT devices using [Device SDKs](/firmware). These are based on different embedded Real Time Operating Systems (RTOS). Currently Golioth targets the [Zephyr Project](https://www.zephyrproject.org/) and builds upon the APIs & tools of Zephyr. As such, prior experience with Zephyr will be helpful when working with [Golioth's Zephyr Device SDK](https://github.com/golioth/zephyr-sdk). Refer to Zephyr's [detailed documentation](https://docs.zephyrproject.org/) when running into issues.
@@ -46,7 +49,16 @@ west build -p auto -b  nrf9160dk_nrf9160_ns samples/basic/minimal
 
 ### Flash firmware to the device
 
-#### nRF9160_DK
+<Tabs
+groupId="nrf9160-hw"
+defaultValue="nrf9160dk"
+values={[
+{label: 'nRF9160-DK', value: 'nrf9160dk'},
+{label: 'nRF91 Feather', value: 'nrf91feather'},
+]}>
+
+<TabItem value="nrf9160dk">
+
 
 The official nRF9160 Development Kit has an onboard debugger and can program entire images into the flash using native west commands. However, there is a required nRF CLI tool installation.
 
@@ -61,9 +73,12 @@ Flash the application to the board with the following command:
 ```
 west flash
 ```
-
-#### nRF91 Feather
+</TabItem>
+<TabItem value="nrf91feather">
 
 The nRF91 Feather does not have a debugger onboard like the nRF9160_DK. If you have an external debugger (like a JLink) and a programming cable (the board uses a 6 pin Tag Connect), use can the same directions as the nRF9160_DK flashing, shown above.
 
 If you'd like to load firmware directly to the board using a USB cable, you must compile the firmware to compile a bootload-able image and then use an external tool like [`newtmgr`](https://github.com/circuitdojo/mynewt-newtmgr?organization=circuitdojo&organization=circuitdojo). Follow the directions [on the CircuitDojo wiki to install and flash the image to the nRF91 Feather](https://docs.jaredwolff.com/nrf9160-programming-and-debugging.html#using-newtmgr).
+
+</TabItem>
+</Tabs>

--- a/docs/hardware/4-nrf91/2-quickstart/2-set-up-zephyr.md
+++ b/docs/hardware/4-nrf91/2-quickstart/2-set-up-zephyr.md
@@ -1,11 +1,13 @@
 ---
 id: set-up-zephyr
-title: Set up Zephyr for nRF91
+title: Set up Zephyr for the nRF9160
 ---
 
-Golioth can be added to a device with _Device SDKs_ which are based on different embedded Operating Systems. Currently Golioth targets the [Zephyr Project](https://www.zephyrproject.org/) and builds upon the APIs & tools of Zephyr. As such, prior experience with Zephyr will be helpful when working with Golioth's Zephyr Device SDK. Refer to Zephyr's [detailed documentation](https://docs.zephyrproject.org/) when running into issues.
+### Zephyr Setup Overview
 
-Platforms like nRF9160 Feather require nRF Connect SDK to make use of their distinct features, which is cellular network connectivity. We will install the nRF Connect SDK in a directory in your home location separate from other Zephyr projects shown for Golioth (in a directory called 'zephyr-nrf')
+Golioth is implemented on IoT devices using [Device SDKs](/firmware). These are based on different embedded Real Time Operating Systems (RTOS). Currently Golioth targets the [Zephyr Project](https://www.zephyrproject.org/) and builds upon the APIs & tools of Zephyr. As such, prior experience with Zephyr will be helpful when working with [Golioth's Zephyr Device SDK](https://github.com/golioth/zephyr-sdk). Refer to Zephyr's [detailed documentation](https://docs.zephyrproject.org/) when running into issues.
+
+The nRF9160 Feather and all Nordic Semiconductor devices utilizing Zephyr require the [nRF Connect SDK (NCS)](https://www.nordicsemi.com/Products/Development-software/nRF-Connect-SDK). Nordic Semiconductor maintains a fork of the Zephyr project that includes some distinct features and IP, including the firmware for the cellular modem on the nRF9160. We will install the nRF Connect SDK in a directory in your home location separate from other Zephyr projects shown for Golioth (in a directory called `zephyr-nrf`)
 
 ### Install West
 

--- a/docs/hardware/4-nrf91/2-quickstart/2-set-up-zephyr.md
+++ b/docs/hardware/4-nrf91/2-quickstart/2-set-up-zephyr.md
@@ -9,16 +9,25 @@ Platforms like nRF9160 Feather require nRF Connect SDK to make use of their dist
 
 ### Install West
 
+import SetupWestNRF91 from '/docs/partials/setup-west-nrf91.md'
 
-import SetupZephyr from '/docs/partials/setup-zephyr.md'
-
-<SetupZephyr/>
+<SetupWestNRF91/>
 
 ### Installing the NRF Connect SDK
 
 import InstallNRFSDK from '/docs/partials/install-nrf91-sdk.md'
 
 <InstallNRFSDK/>
+
+### Installing the Zephyr SDK Toolchain
+
+The nRF9160 is an ARM based device, so we will use the ARM toolchains (gcc, gdb, etc) included in the Zephyr SDK
+
+import InstallZephyrSDKtoolchain from '/docs/partials/install-zephyr-sdk-toolchain.md'
+
+<InstallZephyrSDKtoolchain/>
+
+### Build firmware for the nRF9160
 
 Your system is all set up and ready to start building & flashing with Zephyr. Verify by building a minimal sample, in this case for the CircuitDojo nRF91 feather:
 
@@ -32,6 +41,8 @@ Alternatively, build for the nRF9160_DK with the following commands:
 cd ~/zephyr-nrf/zephyr
 west build -p auto -b  nrf9160dk_nrf9160_ns samples/basic/minimal
 ```
+
+### Flash firmware to the nRF9160
 
 Flash the application to the board with the following command:
 ```

--- a/docs/hardware/4-nrf91/2-quickstart/2-set-up-zephyr.md
+++ b/docs/hardware/4-nrf91/2-quickstart/2-set-up-zephyr.md
@@ -42,9 +42,26 @@ cd ~/zephyr-nrf/zephyr
 west build -p auto -b  nrf9160dk_nrf9160_ns samples/basic/minimal
 ```
 
-### Flash firmware to the nRF9160
+### Flash firmware to the device
+
+#### nRF9160_DK
+
+The official nRF9160 Development Kit has an onboard debugger and can program entire images into the flash using native west commands. However, there is a required nRF CLI tool installation.
+
+[Download the package here](https://www.nordicsemi.com/Products/Development-tools/nrf-command-line-tools/download) and unpack the archive (Linux)
+
+```
+sudo dpkg -i JLink_Linux_V758b_x86_64.deb
+sudo dpkg -i nrf-command-line-tools_10.15.1_amd64.deb
+```
 
 Flash the application to the board with the following command:
 ```
 west flash
 ```
+
+#### nRF91 Feather
+
+The nRF91 Feather does not have a debugger onboard like the nRF9160_DK. If you have an external debugger (like a JLink) and a programming cable (the board uses a 6 pin Tag Connect), use can the same directions as the nRF9160_DK flashing, shown above.
+
+If you'd like to load firmware directly to the board using a USB cable, you must compile the firmware to compile a bootload-able image and then use an external tool like [`newtmgr`](https://github.com/circuitdojo/mynewt-newtmgr?organization=circuitdojo&organization=circuitdojo). Follow the directions [on the CircuitDojo wiki to install and flash the image to the nRF91 Feather](https://docs.jaredwolff.com/nrf9160-programming-and-debugging.html#using-newtmgr).

--- a/docs/hardware/4-nrf91/2-quickstart/4-flash-sample.md
+++ b/docs/hardware/4-nrf91/2-quickstart/4-flash-sample.md
@@ -1,9 +1,9 @@
 ---
 id: flash-sample
-title: Flashing an nRF91 with samples
+title: Flashing an nRF9160 with samples
 ---
 
-The sample code uses the network interface provided on the nRF91 (cellular) and passes packets back to the Golioth network in this. If you're familiar with Zephyr you may recognized the `LOG_*` functions. That's because Golioth tries to use Zephyr APIs whenever it can. In this instance, the Logging Device Service is a cloud-enabled backend for Zephyr's [logging](https://docs.zephyrproject.org/latest/reference/logging/index.html) library. In this way, Golioth can reuse well-tested libraries, reduce the size through shared code and feel idiomatic to developers who are comfortable with Zephyr.
+The sample code uses the network interface provided on the nRF9160 (cellular) and passes packets back to the Golioth network in this. If you're familiar with Zephyr you may recognized the `LOG_*` functions. That's because Golioth tries to use Zephyr APIs whenever it can. In this instance, the Logging Device Service is a cloud-enabled backend for Zephyr's [logging](https://docs.zephyrproject.org/latest/reference/logging/index.html) library. In this way, Golioth can reuse well-tested libraries, reduce the size through shared code and feel idiomatic to developers who are comfortable with Zephyr.
 
 The sample we'll be using is called `hello`, which logs a "hello" message using the _Logging Device Service_. Here's snippet of the `main()` function:
 

--- a/docs/partials/install-nrf91-sdk.md
+++ b/docs/partials/install-nrf91-sdk.md
@@ -2,6 +2,11 @@
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+:::note
+These directions are mirroring [the Zephyr and Python dependency install instructions](https://docs.zephyrproject.org/latest/getting_started/index.html#get-zephyr-and-install-python-dependencies). Some directions may be slightly modified to fit your nRF91 / Golioth install.
+:::
+
+
 With `west` installed, grab the Device SDK:
 
 
@@ -10,7 +15,7 @@ cd ~
 west init -m https://github.com/nrfconnect/sdk-nrf --mr v1.7.0-rc2 ~/zephyr-nrf
 cd zephyr-nrf/
 ```
-Locate the west.yml file under the nrf folder.
+Locate the west.yml file under the `nrf` folder.
 Add the following to west.yml file in the manifest/projects subtree to add the Golioth SDK and dependencies to the NRF Connect SDK:
 ```
 # Golioth repository.

--- a/docs/partials/install-nrf91-sdk.md
+++ b/docs/partials/install-nrf91-sdk.md
@@ -29,7 +29,6 @@ Add the following to west.yml file in the manifest/projects subtree to add the G
 Do the following to redeploy zephyr and add the Golioth SDK library.
 ```
 west update
-west patch
 ```
 
 Tell `west` to automatically configure CMake:

--- a/docs/partials/install-zephyr-sdk-toolchain.md
+++ b/docs/partials/install-zephyr-sdk-toolchain.md
@@ -39,6 +39,7 @@ sudo udevadm control --reload
 
 </TabItem>
 <TabItem value="macos">
+
 Follow the instructions in [Set Up a Toolchain (External Zephyr page)](https://docs.zephyrproject.org/latest/guides/beyond-GSG.html#gs-toolchain). Note that the Zephyr SDK is not available on macOS.
 
 Do not forget to set the required [environment variables](https://docs.zephyrproject.org/latest/guides/env_vars.html#env-vars) (`ZEPHYR_TOOLCHAIN_VARIANT` and toolchain specific ones).

--- a/docs/partials/install-zephyr-sdk-toolchain.md
+++ b/docs/partials/install-zephyr-sdk-toolchain.md
@@ -1,0 +1,58 @@
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+:::note
+These directions are mirroring [the Zephyr toolchain install instructions](https://docs.zephyrproject.org/latest/getting_started/index.html#install-a-toolchain). Some directions may be slightly modified to fit your nRF91 / Golioth install.
+:::
+
+Download the [latest SDK installer](https://github.com/zephyrproject-rtos/sdk-ng/releases):
+
+
+<Tabs
+groupId="zephyr-sdk-toolchain-os"
+defaultValue="ubuntu"
+values={[
+{label: 'Ubuntu', value: 'ubuntu'},
+{label: 'MacOS', value: 'macos'},
+{label: 'Windows', value: 'windows'},
+]}>
+<TabItem value="ubuntu">
+
+```
+cd ~
+wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.13.2/zephyr-sdk-0.13.2-linux-x86_64-setup.run
+```
+
+Run the installer, installing the SDK in ~/zephyr-sdk-0.13.2:
+
+```
+chmod +x zephyr-sdk-0.13.2-linux-x86_64-setup.run
+./zephyr-sdk-0.13.2-linux-x86_64-setup.run -- -d ~/zephyr-sdk-0.13.2
+```
+
+Install udev rules, which allow you to flash most Zephyr boards as a regular user:
+
+```
+sudo cp ~/zephyr-sdk-0.13.2/sysroots/x86_64-pokysdk-linux/usr/share/openocd/contrib/60-openocd.rules /etc/udev/rules.d
+sudo udevadm control --reload
+```
+
+</TabItem>
+<TabItem value="macos">
+Follow the instructions in [Set Up a Toolchain (External Zephyr page)](https://docs.zephyrproject.org/latest/guides/beyond-GSG.html#gs-toolchain). Note that the Zephyr SDK is not available on macOS.
+
+Do not forget to set the required [environment variables](https://docs.zephyrproject.org/latest/guides/env_vars.html#env-vars) (`ZEPHYR_TOOLCHAIN_VARIANT` and toolchain specific ones).
+
+</TabItem>
+<TabItem value="windows">
+
+[The nRF Connect For Desktop](https://www.nordicsemi.com/Products/Development-tools/nRF-Connect-for-desktop) installer includes a Toolchain Manager section that handles many of the same functions described in the Ubuntu tab. This can be used in conjunction with [the VS Code extension for nRF Connect SDK (NCS)](https://www.nordicsemi.com/Products/Development-tools/nRF-Connect-for-VS-Code). This is the recommended path for Windows users with the nRF9160. 
+
+:::note
+
+Using the VS Code extension in conjuction with the nRF Connect for Desktop tools may move you outside many of the other recommended methods of compiling your firmware, described on this docs page and elsewhere on Golioth. If you're having problems with your Windows install, please contact us on our [Community Discord](https://golioth.io/discord)
+
+:::
+
+</TabItem>
+</Tabs>

--- a/docs/partials/setup-west-nrf91.md
+++ b/docs/partials/setup-west-nrf91.md
@@ -7,16 +7,16 @@ import TabItem from '@theme/TabItem';
 
 <Tabs
 groupId="os"
-defaultValue="linux"
+defaultValue="ubuntu"
 values={[
-{label: 'Linux', value: 'linux'},
+{label: 'Ubuntu', value: 'ubuntu'},
 {label: 'MacOS', value: 'macos'},
 {label: 'Windows', value: 'windows'},
 ]}>
 
 import SetupZephyrUnix from './setup-zephyr-unix.md'
 
-<TabItem value="linux">
+<TabItem value="ubuntu">
 
 Install dependencies with `apt`:
 
@@ -44,9 +44,12 @@ brew install cmake ninja gperf python3 ccache qemu dtc
 </TabItem>
 <TabItem value="windows">
 
-:::caution
-While Windows is supported by Zephyr, Golioth does not yet have instructions for
-Windows.
+[The nRF Connect For Desktop](https://www.nordicsemi.com/Products/Development-tools/nRF-Connect-for-desktop) installer includes a Toolchain Manager section that handles many of the same functions described in the Ubuntu tab. This can be used in conjunction with [the VS Code extension for nRF Connect SDK (NCS)](https://www.nordicsemi.com/Products/Development-tools/nRF-Connect-for-VS-Code). This is the recommended path for Windows users with the nRF9160. 
+
+:::note
+
+Using the VS Code extension in conjuction with the nRF Connect for Desktop tools may move you outside many of the other recommended methods of compiling your firmware, described on this docs page and elsewhere on Golioth. If you're having problems with your Windows install, please contact us on our [Community Discord](https://golioth.io/discord)
+
 :::
 
 </TabItem>


### PR DESCRIPTION
- Removing `west patch` fixes #134 
- Adding SDK install steps fixes nRF91 build steps.
