### PR TITLE
nrf91: sync setup of west workspace with SDK

### DIFF
--- a/docs/hardware/4-nrf91/2-quickstart/2-set-up-zephyr.md
+++ b/docs/hardware/4-nrf91/2-quickstart/2-set-up-zephyr.md
@@ -38,7 +38,7 @@ Your system is all set up and ready to start building & flashing with Zephyr. Ve
 
 ```
 cd ~/zephyr-nrf/zephyr
-west build -p auto -b  circuitdojo_feather_nrf9160ns samples/basic/minimal
+west build -p auto -b  circuitdojo_feather_nrf9160_ns samples/basic/minimal
 ```
 Alternatively, build for the nRF9160_DK with the following commands:
 

--- a/docs/partials/install-nrf91-sdk.md
+++ b/docs/partials/install-nrf91-sdk.md
@@ -21,7 +21,7 @@ Add the following to west.yml file in the manifest/projects subtree to add the G
 # Golioth repository.
 - name: golioth
   path: modules/lib/golioth
-  revision: main
+  revision: 309597316d6963832bb777f901e5c869f99daff3
   url: https://github.com/golioth/zephyr-sdk.git
   import:
     name-allowlist:

--- a/docs/partials/install-nrf91-sdk.md
+++ b/docs/partials/install-nrf91-sdk.md
@@ -12,7 +12,7 @@ With `west` installed, grab the Device SDK:
 
 ```
 cd ~
-west init -m https://github.com/nrfconnect/sdk-nrf --mr v1.7.0-rc2 ~/zephyr-nrf
+west init -m https://github.com/nrfconnect/sdk-nrf --mr v1.7.1 ~/zephyr-nrf
 cd zephyr-nrf/
 ```
 Locate the west.yml file under the `nrf` folder.
@@ -23,12 +23,9 @@ Add the following to west.yml file in the manifest/projects subtree to add the G
   path: modules/lib/golioth
   revision: main
   url: https://github.com/golioth/zephyr-sdk.git
-
-# Golioth dependencies.
-- name: qcbor
-  revision: 17b5607b8c49b835d22dec3effa97b25c89267b3
-  url: https://github.com/golioth/QCBOR.git
-  path: modules/lib/qcbor
+  import:
+    name-allowlist:
+      - qcbor
 
 ```
 Do the following to redeploy zephyr and add the Golioth SDK library.


### PR DESCRIPTION
During west workspace setup we need to use newer version of NCS, as the
old version is not compatible with changes in SDK.

Update also how QCBOR is added as dependency to west.yml file (by
importing it from Golioth SDK manifest), so that its version does not
need to be specified explicitly.

Remove `west patch` step, as it was not required for long time and it
actually creates problems and confuses users.

Fixes: #134
Fixes: #131