### PR TITLE
Use https as remote instead of ssh

### DIFF
--- a/docs/cloud/1-services/5-ota/2-uploading-artifacts.md
+++ b/docs/cloud/1-services/5-ota/2-uploading-artifacts.md
@@ -18,7 +18,7 @@ Here are the steps to build and sign your image with version `1.0.1` and both wi
 - For Nordic Zephyr SDK and the nrf9160 Feather board
 
 ```
-$ west build -b circuitdojo_feather_nrf9160ns samples/dfu -p -- -DCONFIG_MCUBOOT_IMAGE_VERSION=\"1.0.1\"
+$ west build -b circuitdojo_feather_nrf9160_ns samples/dfu -p -- -DCONFIG_MCUBOOT_IMAGE_VERSION=\"1.0.1\"
 ```
 
 - For Pure Zephyr SDK and a nrf52840-dk board

--- a/docs/hardware/4-nrf91/2-quickstart/4-flash-sample.md
+++ b/docs/hardware/4-nrf91/2-quickstart/4-flash-sample.md
@@ -56,7 +56,7 @@ Set the PSK & PSK ID to match what was used during the provisioning step. Networ
 After saving, build the sample (for the [CircuitDojo nRF91 Feather](https://www.jaredwolff.com/store/nrf9160-feather/)) with the new settings applied.
 
 ```
-west build -b circuitdojo_feather_nrf9160ns samples/hello -p
+west build -b circuitdojo_feather_nrf9160_ns samples/hello -p
 ```
 
 ### Flashing the device

--- a/docs/partials/install-zephyr-sdk.md
+++ b/docs/partials/install-zephyr-sdk.md
@@ -9,7 +9,7 @@ Depending on your internet and I/O speed, `west update` can take upwards of 5 or
 
 ```
 cd ~
-west init -m git@github.com:golioth/zephyr.git --mr main ~/zephyrproject
+west init -m https://github.com/golioth/zephyr-sdk.git --mr main ~/zephyrproject
 cd zephyrproject/
 west update
 west patch


### PR DESCRIPTION
As suggested by @ChrisGammell 

>should we be pointing people at the ssh logged in version of git repos?
>(the `west init`  line)
>installing on my new laptop and wasn't verified on github yet
>it might behoove us to either switch to the https version of the clone command or to mention people should have a login for github

The nRF sdk is already using an https remote instead of an ssh one:
https://github.com/golioth/docs/blob/eddd0e0b62930ba5422d19fd739bd8b26fe86894/docs/partials/install-nrf91-sdk.md?plain=1#L15