### PR TITLE
docs: add documentation about the filters introduced in the Logs and LightDb Stream realtime endpoints

### DIFF
--- a/docs/reference/5-websocket/3-Endpoints/1-lightdb.md
+++ b/docs/reference/5-websocket/3-Endpoints/1-lightdb.md
@@ -5,38 +5,37 @@ title: LightDB
 
 [LightDB Device Service](/cloud/services/lightdb) definitions.
 
-Real-Time Endpoint to listen to any changes in a device state path.
+Real-time endpoint to listen to any changes in a device state path.
 
-
-### Interface
-
+## Interface
 
 | Method    | Description                       | Complete Endpoint                                               | Content Format |
 | --------- | --------------------------------- | --------------------------------------------------------------- | -------------- |
 | WebSocket | Listening to LightDB Device State | wss://api.golioth.io/v1/ws/projects/{projectId}/devices/{deviceId}/data{/path=\*\*}?{x-api-key\|jwt}={API_KEY\|JWT} | JSON |
 
-To open the WebSocket connection you will make an HTTP Request for a websocket endpoint, passing the following parameteres:
+To open the WebSocket connection, you will make an HTTP Request for a websocket endpoint, passing the following parameters:
 
-|Parameter             | Optional | Description                                                                                            |
-|--------------------- | -------- | ------------------------------------------------------------------------------------------------------ |
-|`projectId`           | **false** | ID of the project                                                                                      |
-|`deviceId`            | **false** | ID of the device                                                                                       |
-|`path` to be listened to | true    | _'empty path'_ if desired to listen to the root path <br /> _'some path'_ to listen to a specific path <br /> Ex: '/data', '/data/temp', '/data/temp/state' |
-|`API_KEY` or `JWT`            | **false** | Api Key or JWT valid for the ProjectID passed to authenticate to the Golioth |
+|Parameter             | Optional  | Description                                                                  |
+|--------------------- | --------- | -----------------------------------------------------------------------------|
+|`projectId`           | **false** | ID of the project                                                            |
+|`deviceId`            | **false** | ID of the device                                                             |
+|`path`                | **true**  | Path to listen to<br /><br />- Omit the path parameter to listen to the root path<br />- Format as _`/some/path`_ to listen to that specific path. Ex: `/data`, `/data/temp`, `/data/temp/state`|
+|`API_KEY` or `JWT`    | **false** | API Key or JWT valid for the ProjectID passed to authenticate to the Golioth |
 
-### Use Cases
+## Use Cases
 
-#### Listening to real-time device state change via WebSocket
+While the GET method only allows you to receive one data packet at a time, WebSocket makes it possible to keep a persistent flow of data coming from the LightDB at the moment the state is changed. In other words, with WebSocket you are able to listen to changes in real-time. You'll see data arriving at your WebSocket client as soon as the data sent by the device arrives on the Golioth Cloud. The WebSocket will continue listening until the connection is closed.
 
-While the GET method only allows you to receive one data packet at a time, WebSocket makes it possible keeping a persistent flow of data coming from the LightDB at the moment the state is changed. In other words, with WebSocket you are able to listen to changes in real-time.
+### Listening to real-time device state changes via WebSocket
 
-For example, for listening to any changes in the `/env` path, connect a WebSocket client to the following endpoint:
+For example, to listen to any changes in the `/env` path of a project called `local-test`, connect a WebSocket client to the following endpoint:
 ```
 wss://api.golioth.io/v1/ws/projects/local-test/devices/6173155307bbb1c7c9bb158f/data/env?x-api-key=AAABbBbBbCcCcCcDdDdDdEeEe1H2E3KJ==
 ```
 
-You'll see data arriving to your WebSocket client as soon as the `/env` path is either modified or deleted indefinitely, or until the connection is closed:
-```
+You'll see data arriving to your WebSocket client each time the `/env` path is either modified or deleted:
+
+```json
 {"result": {"data": {"temp": {"value" : 45.2, "unit" : "c"}}}}
 {"result": {"data": {"temp": {"value" : 45.3, "unit" : "c"}}}}
 {"result": {"data": {"temp": {"value" : 45.1, "unit" : "c"}}}}
@@ -46,11 +45,14 @@ You'll see data arriving to your WebSocket client as soon as the `/env` path is 
 ```
 
 If you want to listen to the entire device state without specifying any particular path, just omit the path:
+
 ```
 wss://api.golioth.io/v1/ws/projects/local-test/devices/6173155307bbb1c7c9bb158f/data?x-api-key=AAABbBbBbCcCcCcDdDdDdEeEe1H2E3KJ==
 ```
+
 In this case you will see data arriving for the entire device state:
-```
+
+```json
 {"result": {"data": {"env": {"temp": {"value" : 45.2, "unit" : "c"}}, "alert": {"temp": true}, "config": {"temp": {"min": 20.0,"max": 40.0}}}}}
 {"result": {"data": {"env": {"temp": {"value" : 45.3, "unit" : "c"}}, "alert": {"temp": true}, "config": {"temp": {"min": 20.0,"max": 40.0}}}}}
 {"result": {"data": {"env": {"temp": {"value" : 45.1, "unit" : "c"}}, "alert": {"temp": true}, "config": {"temp": {"min": 20.0,"max": 40.0}}}}}

--- a/docs/reference/5-websocket/3-Endpoints/2-lightdb-stream.md
+++ b/docs/reference/5-websocket/3-Endpoints/2-lightdb-stream.md
@@ -5,48 +5,57 @@ title: LightDB Stream
 
 [LightDB Stream Device Service](/cloud/services/lightdb-stream) definitions.
 
-Real-Time Endpoint to listen to device's stream data incoming to the platform.
+Real-time endpoint to listen to a device's data stream as it arrives at the Golioth Cloud.
 
+## Interface
 
-### Interface
+| Method    | Description                           | Complete Endpoint                                                                                         | Content Format |
+| --------- | ------------------------------------- | --------------------------------------------------------------------------------------------------------- | -------------- |
+| WebSocket | Listening to LightDB Stream           | wss://api.golioth.io/v1/ws/projects/{projectId}/stream?{x-api-key\|jwt}={API_KEY\|JWT}                    | JSON           |
+| WebSocket | Listening to LightDB Stream by Device | wss://api.golioth.io/v1/ws/projects/{projectId}/devices/{deviceId}/stream?{x-api-key\|jwt}={API_KEY\|JWT} | JSON           |
 
+To open the WebSocket connection, you will make an HTTP Request for a websocket endpoint, passing the following `path` and `query` parameters:
 
-| Method    | Description                       | Complete Endpoint                                               | Content Format |
-| --------- | --------------------------------- | --------------------------------------------------------------- | -------------- |
-| WebSocket | Listening to LightDB Stream       | wss://api.golioth.io/v1/ws/projects/{projectId}/stream?{x-api-key\|jwt}={API_KEY\|JWT} | JSON |
+| Parameter          | Type  | Optional                           | Description                                                                  |
+| ------------------ | ----- | ---------------------------------- | ---------------------------------------------------------------------------- |
+| `projectId`        | path  | **false**                          | ID of the project                                                            |
+| `deviceId`         | path  | **false**, if required by endpoint | ID of the device                                                             |
+| `API_KEY` or `JWT` | query | **false**                          | API Key or JWT valid for the ProjectID passed to authenticate to the Golioth |
 
-To open the WebSocket connection you will make an HTTP Request for a websocket endpoint, passing the following parameteres:
+## Use Cases and Examples
 
-|Parameter             | Optional | Description                                                                                            |
-|--------------------- | -------- | ------------------------------------------------------------------------------------------------------ |
-|`projectId`           | **false** | ID of the project                                                                                      |
-|`API_KEY` or `JWT`    | **false** | Api Key or JWT valid for the ProjectID passed to authenticate to the Golioth |
+While the GET method only allows you to receive one data packet at a time, WebSocket makes it possible to keep a persistent flow of data coming from the LightDB at the moment that new stream data is received. In other words, with WebSocket you are able to listen new messages in real-time. You'll see data arriving at your WebSocket client as soon as the data sent by the device arrives on the Golioth Cloud. The WebSocket will continue listening until the connection is closed.
 
-### Filtering Devices Streams
+### Listening to all devices
 
-At the moment it is possible only to listen to all the device's stream of a project, but in the future it will be provided resources to filter specifics kinds of device's streams.
+To listen to all data streams **from all devices** of a project called `local-test`, we can connect a WebSocket client to the following endpoint:
 
-import ComingSoon from '/docs/partials/coming-soon.md'
-
-<ComingSoon/>
-
-### Use Cases
-
-#### Listening to real-time device stream via WebSocket
-
-While the GET method only allows you to receive one data packet at a time, WebSocket makes it possible keeping a persistent flow of data coming from the LightDB at the moment the state is changed. In other words, with WebSocket you are able to listen to changes in real-time.
-
-For example, for listening to the data stream from the devices, connect a WebSocket client to the following endpoint:
 ```
 wss://api.golioth.io/v1/ws/projects/local-test/stream?x-api-key=AAABbBbBbCcCcCcDdDdDdEeEe1H2E3KJ==
 ```
 
-You'll see data arriving to your WebSocket client as soon as the data sent by the device arrive to the platform, indefinitely or until the connection is closed:
-```
+The response:
+
+```json
 {"result":{"data":{"timestamp":"2021-12-01T19:12:53.350079884Z","deviceId":"61a4cfdfb2b45578105aeca5","data":{"temp":29}}}}
-{"result":{"data":{"timestamp":"2021-12-01T19:12:58.365990318Z","deviceId":"61a4cfdfb2b45578105aeca5","data":{"temp":29.5}}}}
-{"result":{"data":{"timestamp":"2021-12-01T19:13:03.384024361Z","deviceId":"61a4cfdfb2b45578105aeca5","data":{"temp":20}}}}
-{"result":{"data":{"timestamp":"2021-12-01T19:13:08.399730505Z","deviceId":"61a4cfdfb2b45578105aeca5","data":{"temp":20.5}}}}
-{"result":{"data":{"timestamp":"2021-12-01T19:13:13.417176929Z","deviceId":"61a4cfdfb2b45578105aeca5","data":{"temp":21}}}}
-{"result":{"data":{"timestamp":"2021-12-01T19:13:18.331914908Z","deviceId":"61a4cfdfb2b45578105aeca5","data":{"temp":21.5}}}}
+{"result":{"data":{"timestamp":"2021-12-01T19:12:58.365990318Z","deviceId":"61a4cfc9b2b45578105aeca3","data":{"led_on":true}}}}
+{"result":{"data":{"timestamp":"2021-12-01T19:13:03.384024361Z","deviceId":"61a4cfdfb2b45578105aeca5","data":{"temp":29.5}}}}
+{"result":{"data":{"timestamp":"2021-12-01T19:13:08.399730505Z","deviceId":"61a4cfc9b2b45578105aeca3","data":{"led_on":false}}}}
+{"result":{"data":{"timestamp":"2021-12-01T19:13:13.417176929Z","deviceId":"61a4cfdfb2b45578105aeca5","data":{"temp":20}}}}
+{"result":{"data":{"timestamp":"2021-12-01T19:13:18.331914908Z","deviceId":"61a4cfdfb2b45578105aeca5","data":{"temp":20.5}}}}
+```
+
+### Listening to a specific device
+
+To listening to all data streams **from a specific device** of a project called `local-test`, we can connect a WebSocket client to the following endpoint:
+
+```
+wss://api.golioth.io/v1/ws/projects/local-test/devices/61a4cfc9b2b45578105aeca3/stream?x-api-key=AAABbBbBbCcCcCcDdDdDdEeEe1H2E3KJ==
+```
+
+The response:
+
+```json
+{"result":{"data":{"timestamp":"2021-12-01T19:12:58.365990318Z","deviceId":"61a4cfc9b2b45578105aeca3","data":{"led_on":true}}}}
+{"result":{"data":{"timestamp":"2021-12-01T19:13:08.399730505Z","deviceId":"61a4cfc9b2b45578105aeca3","data":{"led_on":false}}}}
 ```

--- a/docs/reference/5-websocket/3-Endpoints/3-logging.md
+++ b/docs/reference/5-websocket/3-Endpoints/3-logging.md
@@ -5,47 +5,125 @@ title: Logging
 
 [Logging Device Service](/cloud/services/logging) definitions.
 
-Real-Time Endpoint to listen to device's logs stream incoming to the platform.
+Real-time endpoint to listen to a device's data stream as it arrives at the Golioth Cloud.
 
-### Interface
+## Interface
 
+| Method    | Description                        | Complete Endpoint                                                                                                                     | Content Format |
+| --------- | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
+| WebSocket | Listening to Device Logs           | wss://api.golioth.io/v1/ws/projects/{projectId}/logs?{x-api-key\|jwt}={API_KEY\|JWT}&module={module}&level={level}                    | JSON           |
+| WebSocket | Listening to Device Logs by Device | wss://api.golioth.io/v1/ws/projects/{projectId}/devices/{deviceId}/logs?{x-api-key\|jwt}={API_KEY\|JWT}&module={module}&level={level} | JSON           |
 
-| Method    | Description                       | Complete Endpoint                                               | Content Format |
-| --------- | --------------------------------- | --------------------------------------------------------------- | -------------- |
-| WebSocket | Listening to Device Logs          | wss://api.golioth.io/v1/ws/projects/{projectId}/logs?{x-api-key\|jwt}={API_KEY\|JWT} | JSON |
+To open the WebSocket connection, you will make an HTTP Request for a websocket endpoint, passing the following `path` and `query` parameters:
 
-To open the WebSocket connection you will make an HTTP Request for a websocket endpoint, passing the following parameteres:
+| Parameter          | Type  | Optional                           | Description                                                                                  |
+| ------------------ | ----- | ---------------------------------- | -------------------------------------------------------------------------------------------- |
+| `projectId`        | path  | **false**                          | ID of the project                                                                            |
+| `deviceId`         | path  | **false**, if required by endpoint | ID of the device                                                                             |
+| `API_KEY` or `JWT` | query | **false**                          | API Key or JWT valid for the ProjectID passed to authenticate to the Golioth                 |
+| `module`           | query | **true**                           | Unique module name registered as part of the [Zephyr logging specification](https://docs.zephyrproject.org/latest/reference/logging/index.html#logging-in-a-module)|
+| `level`            | query | **true**                           | Log's Level contained within the log. It can be one of these: NONE, INFO, WARN, ERROR, DEBUG |
 
-|Parameter             | Optional | Description                                                                                            |
-|--------------------- | -------- | ------------------------------------------------------------------------------------------------------ |
-|`projectId`           | **false** | ID of the project                                                                                      |
-|`API_KEY` or `JWT`    | **false** | Api Key or JWT valid for the ProjectID passed to authenticate to the Golioth |
+## Filtering Logs
 
-### Filtering Logs
+It's possible to receive all logs from the entire project, indiscriminately, or a filter can be applied. Available filters include:
 
-At the moment it is possible only to listen to all the logs of a project, but in the future it will be provided resources to filter specifics kinds of logs streams.
+- **`deviceId`**: provide the device's id to receive only logs which match with this specific device
+- **`module`**: provide a log module name to receive only logs which match with this specific module
+- **`level`**: provide a log level name to receive only logs which match with this specific level
 
-import ComingSoon from '/docs/partials/coming-soon.md'
+Filters are optional and you can combine them to receive only the logs that you really want.
 
-<ComingSoon/>
+## Use Cases and Examples
 
-### Use Cases
+While the GET method only allows you to receive one data packet at a time, WebSocket makes it possible to keep a persistent flow of data coming from the LightDB at the moment the state is changed. In other words, with WebSocket you are able to listen to changes in real-time. You'll see data arriving at your WebSocket client as soon as the data sent by the device arrives on the Golioth Cloud. The WebSocket will continue listening until the connection is closed.
 
-#### Listening to real-time device logs stream via WebSocket
+### Listening to all log messages
 
-While the GET method only allows you to receive one data packet at a time, WebSocket makes it possible keeping a persistent flow of data coming from the LightDB at the moment the state is changed. In other words, with WebSocket you are able to listen to changes in real-time.
+To listen to all logs **from all devices** of a project called `local-test`, connect a WebSocket client to the following endpoint:
 
-For example, for listening to the logs stream from the devices, connect a WebSocket client to the following endpoint:
 ```
 wss://api.golioth.io/v1/ws/projects/local-test/logs?x-api-key=AAABbBbBbCcCcCcDdDdDdEeEe1H2E3KJ==
 ```
 
-You'll see data arriving to your WebSocket client as soon as the data sent by the device arrive to the platform, indefinitely or until the connection is closed:
-```
+The response:
+
+```json
 {"result":{"data":{"timestamp":"2021-12-01T19:14:07.376256912Z","type":"LOGGING","level":"DEBUG","module":"golioth_logging","moduleId":"","message":"Log 1: 33","metadata":{"func":"func_1","index":214,"uptime":172271000},"deviceId":"61a4cfc9b2b45578105aeca3"}}}
 {"result":{"data":{"timestamp":"2021-12-01T19:14:07.376201852Z","type":"LOGGING","level":"INFO","module":"golioth_logging","moduleId":"","message":"Counter hexdump","metadata":{"hexdump":"IQAAAA==","index":218,"uptime":172271000},"deviceId":"61a4cfc9b2b45578105aeca3"}}}
-{"result":{"data":{"timestamp":"2021-12-01T19:14:07.376104957Z","type":"LOGGING","level":"DEBUG","module":"golioth_logging","moduleId":"","message":"Log 2: 33","metadata":{"func":"func_2","index":215,"uptime":172271000},"deviceId":"61a4cfc9b2b45578105aeca3"}}}
-{"result":{"data":{"timestamp":"2021-12-01T19:14:07.376117753Z","type":"LOGGING","level":"DEBUG","module":"golioth_logging","moduleId":"","message":"Debug info! 33","metadata":{"func":"main","index":213,"uptime":172271000},"deviceId":"61a4cfc9b2b45578105aeca3"}}}
-{"result":{"data":{"timestamp":"2021-12-01T19:14:07.376104727Z","type":"LOGGING","level":"ERROR","module":"golioth_logging","moduleId":"","message":"Err: 33","metadata":{"index":217,"uptime":172271000},"deviceId":"61a4cfc9b2b45578105aeca3"}}}
-{"result":{"data":{"timestamp":"2021-12-01T19:14:07.376103940Z","type":"LOGGING","level":"WARN","module":"golioth_logging","moduleId":"","message":"Warn: 33","metadata":{"index":216,"uptime":172271000},"deviceId":"61a4cfc9b2b45578105aeca3"}}}
+{"result":{"data":{"timestamp":"2021-12-01T19:14:07.376104957Z","type":"LOGGING","level":"DEBUG","module":"writing","moduleId":"","message":"Log 2: 33","metadata":{"func":"func_2","index":215,"uptime":172271000},"deviceId":"61a4cfdfb2b45578105aeca5"}}}
+{"result":{"data":{"timestamp":"2021-12-01T19:14:07.376117753Z","type":"LOGGING","level":"DEBUG","module":"writing","moduleId":"","message":"Debug info! 33","metadata":{"func":"main","index":213,"uptime":172271000},"deviceId":"61a4cfc9b2b45578105aeca3"}}}
+{"result":{"data":{"timestamp":"2021-12-01T19:14:07.376104727Z","type":"LOGGING","level":"ERROR","module":"monitoring","moduleId":"","message":"Err: 33","metadata":{"index":217,"uptime":172271000},"deviceId":"61a4cfc9b2b45578105aeca3"}}}
+{"result":{"data":{"timestamp":"2021-12-01T19:14:07.376103940Z","type":"LOGGING","level":"WARN","module":"monitoring","moduleId":"","message":"Warn: 33","metadata":{"index":216,"uptime":172271000},"deviceId":"61a4cfdfb2b45578105aeca5"}}}
 ```
+
+### Listening to all logs from a specific device
+
+For listening to all logs **from a specific device** of a project called `local-test`, connect a WebSocket client to the following endpoint:
+
+```
+wss://api.golioth.io/v1/ws/projects/local-test/devices/61a4cfdfb2b45578105aeca5/logs?x-api-key=AAABbBbBbCcCcCcDdDdDdEeEe1H2E3KJ==
+```
+
+The response:
+
+```json
+{"result":{"data":{"timestamp":"2021-12-01T19:14:07.376104957Z","type":"LOGGING","level":"DEBUG","module":"writing","moduleId":"","message":"Log 2: 33","metadata":{"func":"func_2","index":215,"uptime":172271000},"deviceId":"61a4cfdfb2b45578105aeca5"}}}
+{"result":{"data":{"timestamp":"2021-12-01T19:14:07.376103940Z","type":"LOGGING","level":"WARN","module":"monitoring","moduleId":"","message":"Warn: 33","metadata":{"index":216,"uptime":172271000},"deviceId":"61a4cfdfb2b45578105aeca5"}}}
+```
+
+### Combining deviceId, module and level filters to filter the logs
+
+It's possible combine the filters to receive more specifics logs according to your necessity.
+
+- Filtering by `module=monitoring`
+
+  ```
+  wss://api.golioth.io/v1/ws/projects/local-test/logs?x-api-key=AAABbBbBbCcCcCcDdDdDdEeEe1H2E3KJ==&module=monitoring
+  ```
+
+  The response:
+
+  ```json
+  {"result":{"data":{"timestamp":"2021-12-01T19:14:07.376104727Z","type":"LOGGING","level":"ERROR","module":"monitoring","moduleId":"","message":"Err: 33","metadata":{"index":217,"uptime":172271000},"deviceId":"61a4cfc9b2b45578105aeca3"}}}
+  {"result":{"data":{"timestamp":"2021-12-01T19:14:07.376103940Z","type":"LOGGING","level":"WARN","module":"monitoring","moduleId":"","message":"Warn: 33","metadata":{"index":216,"uptime":172271000},"deviceId":"61a4cfdfb2b45578105aeca5"}}}
+  ```
+
+- Filtering by `level=DEBUG`
+
+  ```
+  wss://api.golioth.io/v1/ws/projects/local-test/logs?x-api-key=AAABbBbBbCcCcCcDdDdDdEeEe1H2E3KJ==&level=DEBUG
+  ```
+
+  The response:
+
+  ```json
+  {"result":{"data":{"timestamp":"2021-12-01T19:14:07.376256912Z","type":"LOGGING","level":"DEBUG","module":"golioth_logging","moduleId":"","message":"Log 1: 33","metadata":{"func":"func_1","index":214,"uptime":172271000},"deviceId":"61a4cfc9b2b45578105aeca3"}}}
+  {"result":{"data":{"timestamp":"2021-12-01T19:14:07.376104957Z","type":"LOGGING","level":"DEBUG","module":"writing","moduleId":"","message":"Log 2: 33","metadata":{"func":"func_2","index":215,"uptime":172271000},"deviceId":"61a4cfdfb2b45578105aeca5"}}}
+  {"result":{"data":{"timestamp":"2021-12-01T19:14:07.376117753Z","type":"LOGGING","level":"DEBUG","module":"writing","moduleId":"","message":"Debug info! 33","metadata":{"func":"main","index":213,"uptime":172271000},"deviceId":"61a4cfc9b2b45578105aeca3"}}}
+  ```
+
+- Filtering by `level=DEBUG` and `module=writing`
+
+  ```
+  wss://api.golioth.io/v1/ws/projects/local-test/logs?x-api-key=AAABbBbBbCcCcCcDdDdDdEeEe1H2E3KJ==&level=DEBUG&module=writing
+  ```
+
+  The response:
+
+  ```json
+  {"result":{"data":{"timestamp":"2021-12-01T19:14:07.376104957Z","type":"LOGGING","level":"DEBUG","module":"writing","moduleId":"","message":"Log 2: 33","metadata":{"func":"func_2","index":215,"uptime":172271000},"deviceId":"61a4cfdfb2b45578105aeca5"}}}
+  {"result":{"data":{"timestamp":"2021-12-01T19:14:07.376117753Z","type":"LOGGING","level":"DEBUG","module":"writing","moduleId":"","message":"Debug info! 33","metadata":{"func":"main","index":213,"uptime":172271000},"deviceId":"61a4cfc9b2b45578105aeca3"}}}
+  ```
+
+- Filtering by deviceId `61a4cfc9b2b45578105aeca3` and `level=DEBUG` and `module=writing`
+
+  ```
+  wss://api.golioth.io/v1/ws/projects/local-test/devices/61a4cfc9b2b45578105aeca3/logs?x-api-key=AAABbBbBbCcCcCcDdDdDdEeEe1H2E3KJ==&level=DEBUG&module=writing
+  ```
+
+  The response:
+
+  ```json
+  {"result":{"data":{"timestamp":"2021-12-01T19:14:07.376117753Z","type":"LOGGING","level":"DEBUG","module":"writing","moduleId":"","message":"Debug info! 33","metadata":{"func":"main","index":213,"uptime":172271000},"deviceId":"61a4cfc9b2b45578105aeca3"}}}
+  ```


### PR DESCRIPTION
PR opened to update the Reference/Websocket section to contain now how to filter the Logs and the LightDB streams.