### PR TITLE
improvement: better export path warning message and placement

### DIFF
--- a/docs/partials/install-espressif-toolchain.md
+++ b/docs/partials/install-espressif-toolchain.md
@@ -4,6 +4,13 @@
 west espressif install
 ```
 
+:::caution
+Pay close attention to the output at the end of the `west espressif install`
+step. You will see the export commands you need to set your environmental
+variables. The `ESPRESSIF_TOOLCHAIN_PATH` shown below may be different on your
+machine.
+:::
+
 Configure the toolchain with environment variables:
 
 ```
@@ -11,7 +18,3 @@ export ZEPHYR_TOOLCHAIN_VARIANT="espressif"
 export ESPRESSIF_TOOLCHAIN_PATH="${HOME}/.espressif/tools/xtensa-esp32-elf/esp-2020r3-8.4.0/xtensa-esp32-elf"
 export PATH=$PATH:$ESPRESSIF_TOOLCHAIN_PATH/bin
 ```
-
-:::caution
-`ESPRESSIF_TOOLCHAIN_PATH` may be different on your machine. Verify location after the `west espressif install` step.
-:::


### PR DESCRIPTION
Reported in #156, I found the placements of this to be a bit awkward. I think @vancefarren's suggestion to mention the output of the previous command is a good one. It makes the most sense to move this warning immediately after that `west espressif install` command. This commit also improves the content of the message.