### PR TITLE
fix: update coap example output

### DIFF
--- a/docs/hardware/5-virtual-device/2-quickstart/3-simulating-devices-coap.md
+++ b/docs/hardware/5-virtual-device/2-quickstart/3-simulating-devices-coap.md
@@ -82,7 +82,7 @@ $ coap --path /echo -m POST --psk-id deadbeef-id@my-project-id --psk supersecret
 Params
 method: POST
 path: /echo
-file read correctly: ./README.md
+body: Hello
 
 url: coap.golioth.io:5684
 pre shared key: deadbeef-id@my-project-id:supersecret


### PR DESCRIPTION
The example uses a string, but the output was referring to reading a file.