### PR TITLE
add: reference link and page for Zephry SDK Doxygen

### DIFF
--- a/docs/reference/1-home.md
+++ b/docs/reference/1-home.md
@@ -15,3 +15,5 @@ The API and SDK reference documentation provides detailed information for each o
 - Command Line Tools
   - [goliothctl](/reference/command-line-tools/goliothctl/goliothctl/)
   - [coap](/reference/command-line-tools/coap/coap/)
+- Zephyr SDK
+  - [Golioth Zephyr SDK Reference](https://golioth-doxygen-dev.web.app/) (External Doxygen)

--- a/docs/reference/6-zephyr-sdk.md
+++ b/docs/reference/6-zephyr-sdk.md
@@ -1,0 +1,8 @@
+---
+id: golioth-zephyr-sdk
+title: Golioth Zephyr SDK
+---
+
+The documentation for the [Golioth Zephyr SDK](https://github.com/golioth/zephyr-sdk/) is automatically generated using Doxygen and can be view at our external reference site:
+
+* [Golioth Zephyr SDK Doxygen Reference](https://golioth-doxygen-dev.web.app/)


### PR DESCRIPTION
It may take some time to integrate the Golioth Zephyr SDK Doxygen with our Docusaurus docs. This PR adds links to the Doxygen site so that its available to users until we have a chance for more through integration.

Edit: Here are the rendered pages for your convenience:

* [Reference section overview](https://golioth-docs-dev--pr171-szczys-link-to-doxyg-30bmggdh.web.app/reference)
* [Golioth Zephyr SDK page](https://golioth-docs-dev--pr171-szczys-link-to-doxyg-30bmggdh.web.app/reference/golioth-zephyr-sdk)