### PR TITLE
fix: update Linux zephyr-sdk install for 0.14.1

### DIFF
--- a/docs/hardware/3-esp32/2-quickstart/2-set-up-zephyr.md
+++ b/docs/hardware/3-esp32/2-quickstart/2-set-up-zephyr.md
@@ -14,14 +14,19 @@ import SetupZephyr from '/docs/partials/setup-zephyr.md'
 
 <SetupZephyr/>
 
-### Install Zephyr SDK
+### Install Golioth Zephyr SDK
 
 import InstallZephyrSDK from '/docs/partials/install-zephyr-sdk.md'
 
 <InstallZephyrSDK/>
 
+### Installing the Zephyr SDK Toolchain
 
-### Install the Espressif (ESP32) toolchain
+import InstallZephyrSDKtoolchain from '/docs/partials/install-zephyr-sdk-toolchain.md'
+
+<InstallZephyrSDKtoolchain/>
+
+### Install the Espressif (ESP32) submodules
 
 import InstallEspressifToolchain from '/docs/partials/install-espressif-toolchain.md'
 

--- a/docs/partials/install-espressif-toolchain-unix.md
+++ b/docs/partials/install-espressif-toolchain-unix.md
@@ -1,21 +1,18 @@
-`west` makes it easy to install the Espressif toolchain:
+`west` makes it easy to install Espressif submodules and OpenOCD configurations:
 
-```
+```shell
 west espressif update
 west espressif install
 ```
 
 :::caution
-Pay close attention to the output at the end of the `west espressif install`
-step. You will see the export commands you need to set your environmental
-variables. The `ESPRESSIF_TOOLCHAIN_PATH` shown below may be different on your
-machine.
-:::
-
-Configure the toolchain with environment variables:
+Older versions of the Zephyr SDK Toolchain (prior to 0.14.2) installed the compiler tools using `west espressif install` and required manually setting environmental variables as follows:
 
 ```
 export ZEPHYR_TOOLCHAIN_VARIANT="espressif"
 export ESPRESSIF_TOOLCHAIN_PATH="${HOME}/.espressif/tools/xtensa-esp32-elf/esp-2020r3-8.4.0/xtensa-esp32-elf"
 export PATH=$PATH:$ESPRESSIF_TOOLCHAIN_PATH/bin
 ```
+
+Now, compiler tools are included in the Zephyr SDK. Manually setting these environmental variables is deprecated and this step is no longer needed. We included this message to help inform users about the changes.
+:::

--- a/docs/partials/install-espressif-toolchain-windows.md
+++ b/docs/partials/install-espressif-toolchain-windows.md
@@ -1,21 +1,17 @@
-1. `west` makes it easy to install the Espressif toolchain:
+`west` makes it easy to install Espressif submodules and OpenOCD configurations:
 
-    ```shell
-    west espressif update
-    west espressif install
-    ```
+```shell
+west espressif update
+west espressif install
+```
 
-2. Configure the toolchain with environment variables:
+:::caution
+Older versions of the Zephyr SDK Toolchain (prior to 0.14.2) installed the compiler tools using `west espressif install` and required manually setting environmental variables as follows:
 
-    :::caution
-    Pay close attention to the output at the end of the `west espressif install`
-    step. **There is currently a bug for Windows** that adds quotes to these
-    variable. **Remove the quotes in these commands** and make sure to use the
-    path that is show in your console (it will differ from what you see below
-    because of the user name).
-    :::
+```shell
+set ESPRESSIF_TOOLCHAIN_PATH=C:\Users\Mike\.espressif\tools\zephyr
+set ZEPHYR_TOOLCHAIN_VARIANT=espressif
+```
 
-    ```shell
-    set ESPRESSIF_TOOLCHAIN_PATH=C:\Users\Mike\.espressif\tools\zephyr
-    set ZEPHYR_TOOLCHAIN_VARIANT=espressif
-    ```
+Now, compiler tools are included in the Zephyr SDK. Manually setting these environmental variables is deprecated and this step is no longer needed. We included this message to help inform users about the changes.
+:::

--- a/docs/partials/install-zephyr-sdk-toolchain.md
+++ b/docs/partials/install-zephyr-sdk-toolchain.md
@@ -1,12 +1,7 @@
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-:::note
-These directions are mirroring [the Zephyr toolchain install instructions](https://docs.zephyrproject.org/latest/getting_started/index.html#install-a-toolchain). Some directions may be slightly modified to fit your nRF91 / Golioth install.
-:::
-
 Download the [latest SDK installer](https://github.com/zephyrproject-rtos/sdk-ng/releases):
-
 
 <Tabs
 groupId="os"

--- a/docs/partials/install-zephyr-sdk-toolchain.md
+++ b/docs/partials/install-zephyr-sdk-toolchain.md
@@ -59,11 +59,17 @@ cd zephyr-sdk-0.14.1
 </TabItem>
 <TabItem value="windows">
 
-[The nRF Connect For Desktop](https://www.nordicsemi.com/Products/Development-tools/nRF-Connect-for-desktop) installer includes a Toolchain Manager section that handles many of the same functions described in the Ubuntu tab. This can be used in conjunction with [the VS Code extension for nRF Connect SDK (NCS)](https://www.nordicsemi.com/Products/Development-tools/nRF-Connect-for-VS-Code). This is the recommended path for Windows users with the nRF9160. 
+Unpack the archive and run the installer. The SDK will be placed in the `%HOMEPATH%\zephyr-sdk-0.14.1` directory:
 
-:::note
+```console
+cd %HOMEPATH%
+wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.14.1/zephyr-sdk-0.14.1_windows-x86_64.zip
+unzip zephyr-sdk-0.14.1_windows-x86_64.zip
+cd zephyr-sdk-0.14.1
+setup.cmd
+```
 
-Using the VS Code extension in conjuction with the nRF Connect for Desktop tools may move you outside many of the other recommended methods of compiling your firmware, described on this docs page and elsewhere on Golioth. If you're having problems with your Windows install, please contact us on our [Community Discord](https://golioth.io/discord)
+Answer `y` to both of the questions asked during the setup process.
 
 :::
 

--- a/docs/partials/install-zephyr-sdk-toolchain.md
+++ b/docs/partials/install-zephyr-sdk-toolchain.md
@@ -18,33 +18,43 @@ values={[
 ]}>
 <TabItem value="linux">
 
-```
+```console
 cd ~
-wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.14.0/zephyr-sdk-0.14.0_linux-x86_64.tar.gz
+wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.14.1/zephyr-sdk-0.14.1_linux-x86_64.tar.gz
 ```
 
-Run the installer, installing the SDK in `~/zephyr-sdk-0.14.0`:
+Unpack the archive and run the installer. The SDK will be placed in the `~/zephyr-sdk-0.14.1` directory:
 
-```
-tar -xvf zephyr-sdk-0.14.0_linux-x86_64.tar.gz
-cd zephyr-sdk-0.14.0/
+```console
+tar -xvf zephyr-sdk-0.14.1_linux-x86_64.tar.gz
+cd zephyr-sdk-0.14.1
 ./setup.sh
 ```
+
 Answer `y` to both of the questions asked during the setup process.
 
 Install udev rules, which allow you to flash most Zephyr boards as a regular user:
 
-```
-sudo cp ~/zephyr-sdk-0.14.0/sysroots/x86_64-pokysdk-linux/usr/share/openocd/contrib/60-openocd.rules /etc/udev/rules.d/
+```console
+sudo cp ~/zephyr-sdk-0.14.1/sysroots/x86_64-pokysdk-linux/usr/share/openocd/contrib/60-openocd.rules /etc/udev/rules.d/
 sudo udevadm control --reload
 ```
 
 </TabItem>
 <TabItem value="macos">
 
-Follow the instructions in [Set Up a Toolchain (External Zephyr page)](https://docs.zephyrproject.org/latest/guides/beyond-GSG.html#gs-toolchain). Note that the Zephyr SDK is not available on macOS.
+```console
+cd ~
+wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.14.1/zephyr-sdk-0.14.1_macos-x86_64.tar.gz
+```
 
-Do not forget to set the required [environment variables](https://docs.zephyrproject.org/latest/guides/env_vars.html#env-vars) (`ZEPHYR_TOOLCHAIN_VARIANT` and toolchain specific ones).
+Unpack the archive and run the installer. The SDK will be placed in the `~/zephyr-sdk-0.14.1` directory:
+
+```console
+tar -xvf zephyr-sdk-0.14.1_macos-x86_64.tar.gz
+cd zephyr-sdk-0.14.1
+./setup.sh
+```
 
 </TabItem>
 <TabItem value="windows">

--- a/docs/partials/install-zephyr-sdk-toolchain.md
+++ b/docs/partials/install-zephyr-sdk-toolchain.md
@@ -20,14 +20,14 @@ values={[
 
 ```console
 cd ~
-wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.14.1/zephyr-sdk-0.14.1_linux-x86_64.tar.gz
+wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.14.2/zephyr-sdk-0.14.2_linux-x86_64.tar.gz
 ```
 
-Unpack the archive and run the installer. The SDK will be placed in the `~/zephyr-sdk-0.14.1` directory:
+Unpack the archive and run the installer. The SDK will be placed in the `~/zephyr-sdk-0.14.2` directory:
 
 ```console
-tar -xvf zephyr-sdk-0.14.1_linux-x86_64.tar.gz
-cd zephyr-sdk-0.14.1
+tar -xvf zephyr-sdk-0.14.2_linux-x86_64.tar.gz
+cd zephyr-sdk-0.14.2
 ./setup.sh
 ```
 
@@ -36,7 +36,7 @@ Answer `y` to both of the questions asked during the setup process.
 Install udev rules, which allow you to flash most Zephyr boards as a regular user:
 
 ```console
-sudo cp ~/zephyr-sdk-0.14.1/sysroots/x86_64-pokysdk-linux/usr/share/openocd/contrib/60-openocd.rules /etc/udev/rules.d/
+sudo cp ~/zephyr-sdk-0.14.2/sysroots/x86_64-pokysdk-linux/usr/share/openocd/contrib/60-openocd.rules /etc/udev/rules.d/
 sudo udevadm control --reload
 ```
 
@@ -45,27 +45,27 @@ sudo udevadm control --reload
 
 ```console
 cd ~
-wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.14.1/zephyr-sdk-0.14.1_macos-x86_64.tar.gz
+wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.14.2/zephyr-sdk-0.14.2_macos-x86_64.tar.gz
 ```
 
-Unpack the archive and run the installer. The SDK will be placed in the `~/zephyr-sdk-0.14.1` directory:
+Unpack the archive and run the installer. The SDK will be placed in the `~/zephyr-sdk-0.14.2` directory:
 
 ```console
-tar -xvf zephyr-sdk-0.14.1_macos-x86_64.tar.gz
-cd zephyr-sdk-0.14.1
+tar -xvf zephyr-sdk-0.14.2_macos-x86_64.tar.gz
+cd zephyr-sdk-0.14.2
 ./setup.sh
 ```
 
 </TabItem>
 <TabItem value="windows">
 
-Unpack the archive and run the installer. The SDK will be placed in the `%HOMEPATH%\zephyr-sdk-0.14.1` directory:
+Unpack the archive and run the installer. The SDK will be placed in the `%HOMEPATH%\zephyr-sdk-0.14.2` directory:
 
 ```console
 cd %HOMEPATH%
-wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.14.1/zephyr-sdk-0.14.1_windows-x86_64.zip
-unzip zephyr-sdk-0.14.1_windows-x86_64.zip
-cd zephyr-sdk-0.14.1
+wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.14.2/zephyr-sdk-0.14.2_windows-x86_64.zip
+unzip zephyr-sdk-0.14.2_windows-x86_64.zip
+cd zephyr-sdk-0.14.2
 setup.cmd
 ```
 

--- a/docs/partials/install-zephyr-sdk-toolchain.md
+++ b/docs/partials/install-zephyr-sdk-toolchain.md
@@ -20,20 +20,22 @@ values={[
 
 ```
 cd ~
-wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.13.2/zephyr-sdk-0.13.2-linux-x86_64-setup.run
+wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.14.0/zephyr-sdk-0.14.0_linux-x86_64.tar.gz
 ```
 
-Run the installer, installing the SDK in ~/zephyr-sdk-0.13.2:
+Run the installer, installing the SDK in `~/zephyr-sdk-0.14.0`:
 
 ```
-chmod +x zephyr-sdk-0.13.2-linux-x86_64-setup.run
-./zephyr-sdk-0.13.2-linux-x86_64-setup.run -- -d ~/zephyr-sdk-0.13.2
+tar -xvf zephyr-sdk-0.14.0_linux-x86_64.tar.gz
+cd zephyr-sdk-0.14.0/
+./setup.sh
 ```
+Answer `y` to both of the questions asked during the setup process.
 
 Install udev rules, which allow you to flash most Zephyr boards as a regular user:
 
 ```
-sudo cp ~/zephyr-sdk-0.13.2/sysroots/x86_64-pokysdk-linux/usr/share/openocd/contrib/60-openocd.rules /etc/udev/rules.d
+sudo cp ~/zephyr-sdk-0.14.0/sysroots/x86_64-pokysdk-linux/usr/share/openocd/contrib/60-openocd.rules /etc/udev/rules.d/
 sudo udevadm control --reload
 ```
 


### PR DESCRIPTION
Updates to docs still needed for MacOS and Windows