### PR TITLE
Updating device catalog script to match new docs/links structure

### DIFF
--- a/docs/hardware/assets/hardware-catalog.css
+++ b/docs/hardware/assets/hardware-catalog.css
@@ -1,7 +1,7 @@
-.hide-menu > .menu__link:not(.menu__link--active){
+.hide-menu .menu__link:not(.menu__link--active){
   display: none !important;
 }
-.hide-item > .menu__link:not(.menu__link--active) {
+.hide-item .menu__link:not(.menu__link--active) {
   display: none !important;
 }
 

--- a/scripts/device-catalog/index.js
+++ b/scripts/device-catalog/index.js
@@ -4,7 +4,7 @@ const boardsToJsonFile = require('./boardsToJsonFile');
 const boardToMdx = require('./boardToMdx');
 
 const zephyrRoot = './vendor/zephyr';
-const docsRoot = './docs/hardware/6-boards';
+const docsRoot = './docs/hardware/6-catalog';
 const imgRoot = './static/img/boards';
 const boardsFile = './docs/hardware/assets/boards.json';
 
@@ -49,14 +49,18 @@ function copyBoardImageToBuild(arch, boardId, img, suffix) {
     }
 }
 
+function capitalize(s) {
+    return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
 function createLevelRoot(level) {
     mkdir(`${docsRoot}/${level}`);
     fs.writeFileSync(
         `${docsRoot}/${level}/_category_.yml`,
         `\
-label: '${level.charAt(0).toUpperCase() + level.slice(1)}'
+label: '${level === 'quickstart' ? 'Verified + ' + capitalize(level) : capitalize(level)}'
 collapsible: true
-collapsed: true
+collapsed: false
 ${level === 'unverified' ? 'className: "hide-menu"' : ''}
 `
 );
@@ -165,9 +169,9 @@ boardsToJsonFile(boards, boardsFile);
 
 fs.writeFileSync(`${docsRoot}/_category_.yml`,
 `\
-label: 'Board catalog'
+label: 'Hardware Catalog'
 collapsible: true # make the category collapsible
-collapsed: true # keep the category open by default
+collapsed: false # keep the category open by default
 `
 );
 

--- a/scripts/device-catalog/support.json
+++ b/scripts/device-catalog/support.json
@@ -11,11 +11,11 @@
     },
     "qemu_cortex_m3": {
       "level": "quickstart",
-      "quickstart": "/hardware/virtual-device/quickstart"
+      "quickstart": "/hardware/virtual-devices"
     },
     "qemu_x86": {
       "level": "quickstart",
-      "quickstart": "/hardware/virtual-device/quickstart"
+      "quickstart": "/hardware/virtual-devices"
     }
   },
   "arm64": {},


### PR DESCRIPTION
#### On this PR I updated the script to match with some manual updates add into the Device Catalog, such as:
- Submenu list name update: Quickstart -> Verified + Quickstart
- Root folder name update: 6-boards -> 6-catalog
- Fixed CSS that hides "unverified" menu that stopped working after moving
- Other fixes to make the script match new Device catalog category
  - Root: Hardware Catalog -> Sub-menu: Hardware Catalog Search
  
To test we just need to run the local project as we normally would, and then run the script that generates the Device Catalog.
`npm run build-device-catalog`

And then test if everything match if the live/expected version with the latest zephyr boards.