### PR TITLE
qemu: fix missing apt install, missing west install

### DIFF
--- a/docs/hardware/5-virtual-device/2-quickstart/5-simulating-devices-qemu.md
+++ b/docs/hardware/5-virtual-device/2-quickstart/5-simulating-devices-qemu.md
@@ -3,6 +3,12 @@ id: simulating-devices-qemu
 title: Simulating devices with QEMU
 ---
 
+### Install West
+
+import SetupZephyr from '/docs/partials/setup-zephyr.md'
+
+<SetupZephyr/>
+
 ### Install Zephyr SDK
 
 import InstallZephyrSDK from '/docs/partials/install-zephyr-sdk.md'

--- a/docs/partials/install-qemu-sdk.md
+++ b/docs/partials/install-qemu-sdk.md
@@ -30,7 +30,7 @@ sudo apt install qemu
 Install the necessary tooling:
 
 ```
-sudo apt install libpcap-dev autoconf automake libtool socat net-tools
+sudo apt install libpcap-dev autoconf automake libtool socat net-tools libglib2.0-dev
 ```
 
 Then, compile the zephyr fork of net-tools:
@@ -81,7 +81,7 @@ brew install qemu
 :::info
 QEMU on MacOS does not current support the necessary networking features for simulating a
 network-based Zephyr application.
-See [this issue](https://github.com/zephyrproject-rtos/zephyr/issues/15738) for more information. 
+See [this issue](https://github.com/zephyrproject-rtos/zephyr/issues/15738) for more information.
 :::
 
 </TabItem>


### PR DESCRIPTION
Fixes for things I observed when going through the Virtual Devices guide: https://docs.golioth.io/hardware/virtual-device/quickstart/qemu-install/

* Added libglib2.0-dev to apt install list to prevent the following error on Ubuntu 20.04: `fatal error: glib.h: No such file or directory`
* The snippet to install `west` was missing from Qemu setup page