### PR TITLE
fix: update os tab selector to allow keep state across all pages

### DIFF
--- a/docs/partials/check-toolchain.md
+++ b/docs/partials/check-toolchain.md
@@ -14,7 +14,7 @@ This should list the following variable
 If these are set to Espressif, change them to use the default zephyr toolchain (part of the SDK you installed above)
 
 <Tabs
-groupId="arch"
+groupId="os"
 defaultValue="linux"
 values={[
 {label: 'Linux', value: 'linux'},

--- a/docs/partials/install-zephyr-sdk-toolchain.md
+++ b/docs/partials/install-zephyr-sdk-toolchain.md
@@ -9,14 +9,14 @@ Download the [latest SDK installer](https://github.com/zephyrproject-rtos/sdk-ng
 
 
 <Tabs
-groupId="zephyr-sdk-toolchain-os"
-defaultValue="ubuntu"
+groupId="os"
+defaultValue="linux"
 values={[
-{label: 'Ubuntu', value: 'ubuntu'},
+{label: 'Linux', value: 'linux'},
 {label: 'MacOS', value: 'macos'},
 {label: 'Windows', value: 'windows'},
 ]}>
-<TabItem value="ubuntu">
+<TabItem value="linux">
 
 ```
 cd ~

--- a/docs/partials/setup-west-nrf91.md
+++ b/docs/partials/setup-west-nrf91.md
@@ -7,16 +7,16 @@ import TabItem from '@theme/TabItem';
 
 <Tabs
 groupId="os"
-defaultValue="ubuntu"
+defaultValue="linux"
 values={[
-{label: 'Ubuntu', value: 'ubuntu'},
+{label: 'Linux', value: 'linux'},
 {label: 'MacOS', value: 'macos'},
 {label: 'Windows', value: 'windows'},
 ]}>
 
 import SetupZephyrUnix from './setup-zephyr-unix.md'
 
-<TabItem value="ubuntu">
+<TabItem value="linux">
 
 Install dependencies with `apt`:
 


### PR DESCRIPTION
#### What this PR does:
- Following this [task](https://golioth.atlassian.net/browse/GWP-173?atlOrigin=eyJpIjoiNDE1NGEyNjVlMDczNDY0NTk5YzhhMTFhYmJjYmI2YzYiLCJwIjoiaiJ9), I updated all `groupId`s on the Tabs components. Now its possible to have to same selected OS selected across all pages, keeping its state even after refreshing the page.
- Also, I updated some items that were showing `Ubuntu` into `Linux` to keep consistency with majority of the other pages.
    - Please let me know if this is not the expected behavior

#### How to test it:
- Select the OS that you want at any page, and then change/refresh the page to see if it's keeping its state