### PR TITLE
New NCS install method

### DIFF
--- a/docs/hardware/4-nrf91/2-quickstart/2-set-up-zephyr.md
+++ b/docs/hardware/4-nrf91/2-quickstart/2-set-up-zephyr.md
@@ -10,7 +10,7 @@ import TabItem from '@theme/TabItem';
 
 Golioth is implemented on IoT devices using [Device SDKs](/firmware). These are based on different embedded Real Time Operating Systems (RTOS). Currently Golioth targets the [Zephyr Project](https://www.zephyrproject.org/) and builds upon the APIs & tools of Zephyr. As such, prior experience with Zephyr will be helpful when working with [Golioth's Zephyr Device SDK](https://github.com/golioth/golioth-zephyr-sdk). Refer to Zephyr's [detailed documentation](https://docs.zephyrproject.org/) when running into issues.
 
-The nRF9160 Feather and all Nordic Semiconductor devices utilizing Zephyr require the [nRF Connect SDK (NCS)](https://www.nordicsemi.com/Products/Development-software/nRF-Connect-SDK). Nordic Semiconductor maintains a fork of the Zephyr project that includes some distinct features and IP, including the firmware for the cellular modem on the nRF9160. We will install the nRF Connect SDK in a directory in your home location separate from other Zephyr projects shown for Golioth (in a directory called `zephyr-nrf`)
+The nRF9160 Feather and all Nordic Semiconductor devices utilizing Zephyr require the [nRF Connect SDK (NCS)](https://www.nordicsemi.com/Products/Development-software/nRF-Connect-SDK). Nordic Semiconductor maintains a fork of the Zephyr project that includes some distinct features and IP, including the firmware for the cellular modem on the nRF9160. We will install the nRF Connect SDK in a directory in your home location separate from other Zephyr projects shown for Golioth (in a directory called `golioth-ncs-sdk`)
 
 ### Install West
 
@@ -37,7 +37,7 @@ import InstallZephyrSDKtoolchain from '/docs/partials/install-zephyr-sdk-toolcha
 Your system is all set up and ready to start building & flashing with Zephyr. Verify by building a minimal sample for the nRF9160 DK:
 
 ```console
-cd ~/zephyr-nrf/zephyr
+cd ~/golioth-ncs-sdk/zephyr
 west build -p auto -b  nrf9160dk_nrf9160_ns samples/basic/minimal
 ```
 

--- a/docs/hardware/4-nrf91/2-quickstart/2-set-up-zephyr.md
+++ b/docs/hardware/4-nrf91/2-quickstart/2-set-up-zephyr.md
@@ -10,7 +10,7 @@ import TabItem from '@theme/TabItem';
 
 Golioth is implemented on IoT devices using [Device SDKs](/firmware). These are based on different embedded Real Time Operating Systems (RTOS). Currently Golioth targets the [Zephyr Project](https://www.zephyrproject.org/) and builds upon the APIs & tools of Zephyr. As such, prior experience with Zephyr will be helpful when working with [Golioth's Zephyr Device SDK](https://github.com/golioth/golioth-zephyr-sdk). Refer to Zephyr's [detailed documentation](https://docs.zephyrproject.org/) when running into issues.
 
-The nRF9160 Feather and all Nordic Semiconductor devices utilizing Zephyr require the [nRF Connect SDK (NCS)](https://www.nordicsemi.com/Products/Development-software/nRF-Connect-SDK). Nordic Semiconductor maintains a fork of the Zephyr project that includes some distinct features and IP, including the firmware for the cellular modem on the nRF9160. We will install the nRF Connect SDK in a directory in your home location separate from other Zephyr projects shown for Golioth (in a directory called `golioth-ncs-sdk`)
+The nRF9160 Feather and all Nordic Semiconductor devices utilizing Zephyr require the [nRF Connect SDK (NCS)](https://www.nordicsemi.com/Products/Development-software/nRF-Connect-SDK). Nordic Semiconductor maintains a fork of the Zephyr project that includes some distinct features and IP, including the firmware for the cellular modem on the nRF9160. We will install the nRF Connect SDK in a directory in your home location separate from other Zephyr projects shown for Golioth (in a directory called `golioth-ncs-workspace`)
 
 ### Install West
 
@@ -37,7 +37,7 @@ import InstallZephyrSDKtoolchain from '/docs/partials/install-zephyr-sdk-toolcha
 Your system is all set up and ready to start building & flashing with Zephyr. Verify by building a minimal sample for the nRF9160 DK:
 
 ```console
-cd ~/golioth-ncs-sdk/zephyr
+cd ~/golioth-ncs-workspace/zephyr
 west build -p auto -b  nrf9160dk_nrf9160_ns samples/basic/minimal
 ```
 

--- a/docs/hardware/4-nrf91/2-quickstart/3-hardware-programmer.md
+++ b/docs/hardware/4-nrf91/2-quickstart/3-hardware-programmer.md
@@ -34,7 +34,7 @@ During development we suggest using a hardware programmer like the Segger J-Link
 1. Build the project
 
     ```bash
-    cd ~/golioth-ncs-sdk/zephyr
+    cd ~/golioth-ncs-workspace/zephyr
     west build -b nrf9160dk_nrf9160_ns samples/basic/blinky -p
     ```
 

--- a/docs/hardware/4-nrf91/2-quickstart/3-hardware-programmer.md
+++ b/docs/hardware/4-nrf91/2-quickstart/3-hardware-programmer.md
@@ -34,7 +34,7 @@ During development we suggest using a hardware programmer like the Segger J-Link
 1. Build the project
 
     ```bash
-    cd ~/zephyr-nrf/zephyr
+    cd ~/golioth-ncs-sdk/zephyr
     west build -b nrf9160dk_nrf9160_ns samples/basic/blinky -p
     ```
 

--- a/docs/hardware/4-nrf91/2-quickstart/5-flash-sample.md
+++ b/docs/hardware/4-nrf91/2-quickstart/5-flash-sample.md
@@ -34,10 +34,10 @@ If you're familiar with Zephyr you may recognized the `LOG_*` functions. That's 
 
 ### Building `hello`
 
-Samples can be found in Golioth's nRF Connect based SDK ('golioth-ncs-sdk') in the folder `modules/lib/golioth/samples`. We recommend running the commands below from the `modules/lib/golioth` folder.
+Samples can be found in Golioth's nRF Connect based SDK ('golioth-ncs-workspace') in the folder `modules/lib/golioth/samples`. We recommend running the commands below from the `modules/lib/golioth` folder.
 
 ```console
-cd ~/golioth-ncs-sdk/modules/lib/golioth
+cd ~/golioth-ncs-workspace/modules/lib/golioth
 ```
 
 Zephyr uses [Kconfig](https://docs.zephyrproject.org/latest/guides/kconfig/index.html) to manage build settings at scale. Kconfig values can be set a number of ways but for this example we'll take a simple route by modifying `prj.conf`.

--- a/docs/hardware/4-nrf91/2-quickstart/5-flash-sample.md
+++ b/docs/hardware/4-nrf91/2-quickstart/5-flash-sample.md
@@ -34,10 +34,10 @@ If you're familiar with Zephyr you may recognized the `LOG_*` functions. That's 
 
 ### Building `hello`
 
-Samples can be found in the nRF Connect SDK ('zephyr-nrf') in the folder `modules/lib/golioth/samples`. We recommend running the commands below from the `modules/lib/golioth` folder.
+Samples can be found in Golioth's nRF Connect based SDK ('golioth-ncs-sdk') in the folder `modules/lib/golioth/samples`. We recommend running the commands below from the `modules/lib/golioth` folder.
 
 ```console
-cd ~/zephyr-nrf/modules/lib/golioth
+cd ~/golioth-ncs-sdk/modules/lib/golioth
 ```
 
 Zephyr uses [Kconfig](https://docs.zephyrproject.org/latest/guides/kconfig/index.html) to manage build settings at scale. Kconfig values can be set a number of ways but for this example we'll take a simple route by modifying `prj.conf`.

--- a/docs/partials/install-nrf91-sdk.md
+++ b/docs/partials/install-nrf91-sdk.md
@@ -12,8 +12,8 @@ With `west` installed, grab the Device SDK:
 
 ```
 cd ~
-west init -m https://github.com/nrfconnect/sdk-nrf --mr v1.7.1 ~/zephyr-nrf
-cd zephyr-nrf/
+west init -m https://github.com/golioth/zephyr-sdk.git --mf west-ncs.yml ~/golioth-ncs-sdk
+cd golioth-ncs-sdk/
 ```
 Locate the west.yml file under the `nrf` folder.
 Add the following to west.yml file in the manifest/projects subtree to add the Golioth SDK and dependencies to the NRF Connect SDK:
@@ -51,14 +51,14 @@ values={[
 <TabItem value="virtualenv">
 
 ```
-pip install -r ~/zephyr-nrf/zephyr/scripts/requirements.txt
+pip install -r ~/golioth-ncs-sdk/zephyr/scripts/requirements.txt
 ```
 
 </TabItem>
 <TabItem value="global">
 
 ```
-pip3 install -r ~/zephyr-nrf/zephyr/scripts/requirements.txt
+pip3 install -r ~/golioth-ncs-sdk/zephyr/scripts/requirements.txt
 ```
 
 </TabItem>

--- a/docs/partials/install-nrf91-sdk.md
+++ b/docs/partials/install-nrf91-sdk.md
@@ -6,30 +6,12 @@ import TabItem from '@theme/TabItem';
 These directions are mirroring [the Zephyr and Python dependency install instructions](https://docs.zephyrproject.org/latest/getting_started/index.html#get-zephyr-and-install-python-dependencies). Some directions may be slightly modified to fit your nRF91 / Golioth install.
 :::
 
-
-With `west` installed, grab the Device SDK:
-
+With `west` installed, grab the Golioth NCS SDK:
 
 ```
 cd ~
 west init -m https://github.com/golioth/zephyr-sdk.git --mf west-ncs.yml ~/golioth-ncs-workspace
 cd golioth-ncs-workspace
-```
-Locate the west.yml file under the `nrf` folder.
-Add the following to west.yml file in the manifest/projects subtree to add the Golioth SDK and dependencies to the NRF Connect SDK:
-```
-# Golioth repository.
-- name: golioth
-  path: modules/lib/golioth
-  revision: 309597316d6963832bb777f901e5c869f99daff3
-  url: https://github.com/golioth/golioth-zephyr-sdk.git
-  import:
-    name-allowlist:
-      - qcbor
-
-```
-Do the following to redeploy zephyr and add the Golioth SDK library.
-```
 west update
 ```
 

--- a/docs/partials/install-nrf91-sdk.md
+++ b/docs/partials/install-nrf91-sdk.md
@@ -12,8 +12,8 @@ With `west` installed, grab the Device SDK:
 
 ```
 cd ~
-west init -m https://github.com/golioth/zephyr-sdk.git --mf west-ncs.yml ~/golioth-ncs-sdk
-cd golioth-ncs-sdk/
+west init -m https://github.com/golioth/zephyr-sdk.git --mf west-ncs.yml ~/golioth-ncs-workspace
+cd golioth-ncs-workspace
 ```
 Locate the west.yml file under the `nrf` folder.
 Add the following to west.yml file in the manifest/projects subtree to add the Golioth SDK and dependencies to the NRF Connect SDK:
@@ -51,14 +51,14 @@ values={[
 <TabItem value="virtualenv">
 
 ```
-pip install -r ~/golioth-ncs-sdk/zephyr/scripts/requirements.txt
+pip install -r ~/golioth-ncs-workspace/zephyr/scripts/requirements.txt
 ```
 
 </TabItem>
 <TabItem value="global">
 
 ```
-pip3 install -r ~/golioth-ncs-sdk/zephyr/scripts/requirements.txt
+pip3 install -r ~/golioth-ncs-workspace/zephyr/scripts/requirements.txt
 ```
 
 </TabItem>

--- a/docs/partials/install-nrf91-sdk.md
+++ b/docs/partials/install-nrf91-sdk.md
@@ -10,7 +10,7 @@ With `west` installed, grab the Golioth NCS SDK:
 
 ```
 cd ~
-west init -m https://github.com/golioth/zephyr-sdk.git --mf west-ncs.yml ~/golioth-ncs-workspace
+west init -m https://github.com/golioth/golioth-zephyr-sdk.git --mf west-ncs.yml ~/golioth-ncs-workspace
 cd golioth-ncs-workspace
 west update
 ```

--- a/docs/partials/nrf9160-bootloader-flashing.md
+++ b/docs/partials/nrf9160-bootloader-flashing.md
@@ -75,7 +75,7 @@ We'll use Zephyr's default blinky project as an example:
 1. Change to the Zephyr directory:
 
     ```bash
-    cd ~/zephyr-nrf/zephyr
+    cd ~/golioth-ncs-sdk/zephyr
     ```
 
 2. Add the `CONFIG_BOOTLOADER_MCUBOOT` flag to the project's `prj.conf` file.

--- a/docs/partials/nrf9160-bootloader-flashing.md
+++ b/docs/partials/nrf9160-bootloader-flashing.md
@@ -75,7 +75,7 @@ We'll use Zephyr's default blinky project as an example:
 1. Change to the Zephyr directory:
 
     ```bash
-    cd ~/golioth-ncs-sdk/zephyr
+    cd ~/golioth-ncs-workspace/zephyr
     ```
 
 2. Add the `CONFIG_BOOTLOADER_MCUBOOT` flag to the project's `prj.conf` file.


### PR DESCRIPTION
* Change directions to use west-ncs.yml manifest install method
* Change all nRF-based directory mentions from zephyr-nrf to golioth-ncs-sdk
