### PR TITLE
change: new install method for Golioth Zephry SDK

### DIFF
--- a/docs/hardware/3-esp32/2-quickstart/2-set-up-zephyr.md
+++ b/docs/hardware/3-esp32/2-quickstart/2-set-up-zephyr.md
@@ -43,7 +43,7 @@ values={[
 <TabItem value="linux">
 
 ```shell
-cd ~/zephyrproject/zephyr
+cd ~/golioth-zephyr-workspace/zephyr
 west build -b esp32 samples/basic/minimal -p
 ```
 
@@ -51,7 +51,7 @@ west build -b esp32 samples/basic/minimal -p
 <TabItem value="macos">
 
 ```shell
-cd ~/zephyrproject/zephyr
+cd ~/golioth-zephyr-workspace/zephyr
 west build -b esp32 samples/basic/minimal -p
 ```
 
@@ -61,7 +61,7 @@ west build -b esp32 samples/basic/minimal -p
 1. Verify by building a minimal sample:
 
     ```shell
-    cd C:\zephyrproject\zephyr
+    cd C:\golioth-zephyr-workspace\zephyr
     west build -b esp32 samples\basic\minimal -p
     ```
 

--- a/docs/hardware/3-esp32/2-quickstart/3-flash-sample.md
+++ b/docs/hardware/3-esp32/2-quickstart/3-flash-sample.md
@@ -39,7 +39,7 @@ If you're familiar with Zephyr you may recognized the `LOG_*` functions. That's 
 Samples can be found in the Zephyr SDK in the folder `modules/lib/golioth/samples`. We recommend running the commands below from the `modules/lib/golioth` folder.
 
 ```
-cd ~/zephyrproject/modules/lib/golioth
+cd ~/golioth-zephyr-workspace/modules/lib/golioth
 ```
 
 Zephyr uses [Kconfig](https://docs.zephyrproject.org/latest/guides/kconfig/index.html) to manage build settings at scale. Kconfig values can be set a number of ways but for this example we'll take a simple route by modifying `prj.conf`.

--- a/docs/hardware/5-virtual-device/2-quickstart/5-simulating-devices-qemu.md
+++ b/docs/hardware/5-virtual-device/2-quickstart/5-simulating-devices-qemu.md
@@ -26,7 +26,7 @@ import CheckToolchain from '/docs/partials/check-toolchain.md'
 Navigate to the Golioth directory within Zephyr
 
 ```
-cd ~/zephyrproject/modules/lib/golioth
+cd ~/golioth-zephyr-workspace/modules/lib/golioth
 ```
 This is also the place we will build Zephyr from.
 

--- a/docs/partials/install-zephyr-sdk-unix.md
+++ b/docs/partials/install-zephyr-sdk-unix.md
@@ -9,8 +9,8 @@ Depending on your internet and I/O speed, `west update` can take upwards of 5 or
 
 ```
 cd ~
-west init -m https://github.com/golioth/golioth-zephyr-sdk.git --mr main ~/zephyrproject
-cd zephyrproject/
+west init -m https://github.com/golioth/golioth-zephyr-sdk.git --mf west-zephyr.yml ~/golioth-zephyr-workspace
+cd golioth-zephyr-workspace
 west update
 ```
 
@@ -32,14 +32,14 @@ values={[
 <TabItem value="virtualenv">
 
 ```
-pip install -r ~/zephyrproject/zephyr/scripts/requirements.txt
+pip install -r ~/golioth-zephyr-workspace/zephyr/scripts/requirements.txt
 ```
 
 </TabItem>
 <TabItem value="global">
 
 ```
-pip3 install -r ~/zephyrproject/zephyr/scripts/requirements.txt
+pip3 install -r ~/golioth-zephyr-workspace/zephyr/scripts/requirements.txt
 ```
 
 </TabItem>

--- a/docs/partials/install-zephyr-sdk-windows.md
+++ b/docs/partials/install-zephyr-sdk-windows.md
@@ -5,8 +5,8 @@ import TabItem from '@theme/TabItem';
 
     ```shell
     cd c:\
-    west init -m https://github.com/golioth/golioth-zephyr-sdk.git --mr main zephyrproject
-    cd zephyrproject
+    west init -m https://github.com/golioth/golioth-zephyr-sdk.git --mf west-zephyr.yml golioth-zephyr-workspace
+    cd golioth-zephyr-workspace
     west update
     ```
 
@@ -32,14 +32,14 @@ import TabItem from '@theme/TabItem';
     <TabItem value="virtualenv">
 
     ```
-    pip install -r C:\zephyrproject\zephyr\scripts\requirements.txt
+    pip install -r C:\golioth-zephyr-workspace\zephyr\scripts\requirements.txt
     ```
 
     </TabItem>
     <TabItem value="global">
 
     ```
-    pip3 install -r C:\zephyrproject\zephyr\scripts\requirements.txt
+    pip3 install -r C:\golioth-zephyr-workspace\zephyr\scripts\requirements.txt
     ```
 
     </TabItem>

--- a/docs/partials/setup-zephyr-unix.md
+++ b/docs/partials/setup-zephyr-unix.md
@@ -21,15 +21,15 @@ Even though we haven't pulled down Zephyr yet, we can create the virtual environ
 down Zephyr.
 
 ```
-python3 -m venv ~/zephyrproject/.venv
+python3 -m venv ~/golioth-zephyr-workspace/.venv
 ```
 
 Activate the virtual environment:
 
 ```
-source ~/zephyrproject/.venv/bin/activate
+source ~/golioth-zephyr-workspace/.venv/bin/activate
 # OR, if you're using the fish shell, run
-source ~/zephyrproject/.venv/bin/activate.fish
+source ~/golioth-zephyr-workspace/.venv/bin/activate.fish
 ```
 
 Whenever the virtual environment is active, your shell's prompt will be prefixed with `(.venv)`.

--- a/docs/partials/setup-zephyr-windows.md
+++ b/docs/partials/setup-zephyr-windows.md
@@ -19,16 +19,16 @@ values={[
 
     ```shell
     cd c:\
-    python3 -m venv zephyrproject\.venv
+    python3 -m venv golioth-zephyr-workspace\.venv
     ```
 
 2. Activate the virtual environment:
 
     ```shell
     :: cmd.exe
-    zephyrproject\.venv\Scripts\activate.bat
+    golioth-zephyr-workspace\.venv\Scripts\activate.bat
     :: PowerShell
-    zephyrproject\.venv\Scripts\Activate.ps1
+    golioth-zephyr-workspace\.venv\Scripts\Activate.ps1
     ```
 
     Once activated your shell will be prefixed with `(.venv)`. The virtual environment can be deactivated at any time by running `deactivate`.


### PR DESCRIPTION
* Use west-zephyr.yml instead of west.yml
* Use golioth-zephyr-workspace as the install directory