### PR TITLE
refactor: use relative paths for imports

### DIFF
--- a/docs/partials/install-espressif-toolchain.md
+++ b/docs/partials/install-espressif-toolchain.md
@@ -10,8 +10,8 @@ values={[
 {label: 'Windows', value: 'windows'},
 ]}>
 
-import InstallEspressifToolchainUnix from '/docs/partials/install-espressif-toolchain-unix.md'
-import InstallEspressifToolchainWindows from '/docs/partials/install-espressif-toolchain-windows.md'
+import InstallEspressifToolchainUnix from './install-espressif-toolchain-unix.md'
+import InstallEspressifToolchainWindows from './install-espressif-toolchain-windows.md'
 
 <TabItem value="linux">
 <InstallEspressifToolchainUnix />

--- a/docs/partials/install-zephyr-sdk-toolchain.md
+++ b/docs/partials/install-zephyr-sdk-toolchain.md
@@ -66,7 +66,5 @@ setup.cmd
 
 Answer `y` to both of the questions asked during the setup process.
 
-:::
-
 </TabItem>
 </Tabs>

--- a/docs/partials/install-zephyr-sdk.md
+++ b/docs/partials/install-zephyr-sdk.md
@@ -10,8 +10,8 @@ values={[
 {label: 'Windows', value: 'windows'},
 ]}>
 
-import InstallZephyrSDKUnix from '/docs/partials/install-zephyr-sdk-unix.md'
-import InstallZephyrSDKWindows from '/docs/partials/install-zephyr-sdk-windows.md'
+import InstallZephyrSDKUnix from './install-zephyr-sdk-unix.md'
+import InstallZephyrSDKWindows from './install-zephyr-sdk-windows.md'
 
 <TabItem value="linux">
 <InstallZephyrSDKUnix/>

--- a/docs/partials/setup-zephyr.md
+++ b/docs/partials/setup-zephyr.md
@@ -108,7 +108,7 @@ The [chocolatey](https://chocolatey.org/) package manager needs to be installed 
 
 `west` is the Zephyr "meta tool" that will allow you to build firmware, install packages, and flash firmware. There are various dependencies required, depending upon your operating system (OS), because `west` is Python based.
 
-import SetupZephyrWindows from '/docs/partials/setup-zephyr-windows.md'
+import SetupZephyrWindows from './setup-zephyr-windows.md'
 
 <SetupZephyrWindows />
 


### PR DESCRIPTION
When using this repo as a submodle for other documentation, we
need relative import paths to help avoid breaking the docusaurus
build.