### PR TITLE
Windows install: update for better workflow

### DIFF
--- a/docs/partials/setup-zephyr-windows.md
+++ b/docs/partials/setup-zephyr-windows.md
@@ -1,6 +1,22 @@
+:::note
+Python3 should have been installed by chocolatey in the last step.
+Verify you have version 3 (and not version 2):
+
+1. Open the command line by hitting the Windows key, typing `cmd.exe` and
+   pressing enter.
+2. Type `python`
+3. The interpreter will open and display the version. Type `exit()` to exit.
+
+    ```python
+    Python 3.10.4 (tags/v3.10.4:9d38120, Mar 23 2022, 23:13:41) [MSC v.1929 64 bit (AMD64)] on win32
+    Type "help", "copyright", "credits" or "license" for more information.
+    >>>
+    ```
+
+:::
 
 While the official documentation for Zephyr suggests jumping right into
-installing `west`, we suggest creating a `python3` virtual environment
+installing `west`, we suggest creating a `python` virtual environment
 first, to avoid running into tooling incompatibilities.
 
 import Tabs from '@theme/Tabs';
@@ -19,16 +35,13 @@ values={[
 
     ```shell
     cd c:\
-    python3 -m venv golioth-zephyr-workspace\.venv
+    python -m venv golioth-zephyr-workspace\.venv
     ```
 
 2. Activate the virtual environment:
 
     ```shell
-    :: cmd.exe
-    golioth-zephyr-workspace\.venv\Scripts\activate.bat
-    :: PowerShell
-    golioth-zephyr-workspace\.venv\Scripts\Activate.ps1
+    c:\golioth-zephyr-workspace\.venv\Scripts\activate.bat
     ```
 
     Once activated your shell will be prefixed with `(.venv)`. The virtual environment can be deactivated at any time by running `deactivate`.
@@ -39,7 +52,7 @@ values={[
 
 3. Install west:
 
-    Now, use `pip` to install `west`. Because we're in a `python3` `virtualenv`, we don't need to specify `pip3` and can just use `pip` (because virtual env knows the best version to use)
+    Now, use `pip` to install `west`.
 
     ```shell
     pip install west
@@ -52,7 +65,7 @@ values={[
 1. Use `pip3` to install `west`:
 
     ```shell
-    pip3 install -U west
+    pip install -U west
     ```
 
 </TabItem>

--- a/docs/partials/setup-zephyr.md
+++ b/docs/partials/setup-zephyr.md
@@ -65,15 +65,6 @@ brew install cmake ninja gperf python3 ccache qemu dtc
 
 ### Install Dependencies
 
-#### Python3
-
-1. Open the command line by hitting the Windows key, typing `cmd.exe` and pressing enter.
-2. Type `python3`
-3. If python3 is installed, the interpreter will open and display the version. Type `exit()` to exit.
-4. If python3 is not installed, the Windows Store will automatically open and offer to install it.
-    * Test it: Go back to to the command line, type `python3` to launch then interpreter, `exit()` to exit. 
-    * Alternatively you can [download Python3 directly](https://www.python.org/downloads/windows/) and install it manually.
-
 #### Package Manager: Chocolatey
 
 The [chocolatey](https://chocolatey.org/) package manager needs to be installed to fetch software packages required by Zephyr.
@@ -88,11 +79,9 @@ The [chocolatey](https://chocolatey.org/) package manager needs to be installed 
     ```
 
     ```console
-    > Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
-    > exit
+    Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
+    exit
     ```
-
-    This command may take a few minutes to complete.
 
 3. Disable global confirmation and use `choco` to install remaining dependencies:
 


### PR DESCRIPTION
* Chocolatey installs Python3 so we don't need a separate step
* The `python` command defaults to Python3 (show how to check)
* Remove prompt from powershell commands based on user feedback