### PR TITLE
espressif-install: run from inside SDK

### DIFF
--- a/docs/partials/install-espressif-toolchain-unix.md
+++ b/docs/partials/install-espressif-toolchain-unix.md
@@ -1,6 +1,7 @@
 `west` makes it easy to install Espressif submodules and OpenOCD configurations:
 
 ```shell
+cd ~/golioth-zephyr-workspace
 west espressif update
 west espressif install
 ```

--- a/docs/partials/install-espressif-toolchain-windows.md
+++ b/docs/partials/install-espressif-toolchain-windows.md
@@ -1,6 +1,7 @@
 `west` makes it easy to install Espressif submodules and OpenOCD configurations:
 
 ```shell
+cd c:\golioth-zephyr-workspace
 west espressif update
 west espressif install
 ```


### PR DESCRIPTION
Miguel ran into an error when following the ESP32 Zephyr
Quickstart instructions, on the step where espressif submodules
are updated and installed:

west espressif update
usage: west [-h] [-z ZEPHYR_BASE] [-v] [-V] <command> ...
west: error: argument <command>: invalid choice: ...

This happened because he was in ~/zephyr-sdk-0.14.2 when
he tried to run the command.

The instructions should direct the user to change to the
SDK directory before running the west espressif commands.

Signed-off-by: Nick Miller <nick@golioth.io>