### PR TITLE
Remove warning about ESP32 env variable

### DIFF
--- a/docs/partials/install-espressif-toolchain-unix.md
+++ b/docs/partials/install-espressif-toolchain-unix.md
@@ -6,14 +6,3 @@ west espressif update
 west espressif install
 ```
 
-:::caution
-Older versions of the Zephyr SDK Toolchain (prior to 0.14.2) installed the compiler tools using `west espressif install` and required manually setting environmental variables as follows:
-
-```
-export ZEPHYR_TOOLCHAIN_VARIANT="espressif"
-export ESPRESSIF_TOOLCHAIN_PATH="${HOME}/.espressif/tools/xtensa-esp32-elf/esp-2020r3-8.4.0/xtensa-esp32-elf"
-export PATH=$PATH:$ESPRESSIF_TOOLCHAIN_PATH/bin
-```
-
-Now, compiler tools are included in the Zephyr SDK. Manually setting these environmental variables is deprecated and this step is no longer needed. We included this message to help inform users about the changes.
-:::

--- a/docs/partials/install-espressif-toolchain-windows.md
+++ b/docs/partials/install-espressif-toolchain-windows.md
@@ -6,13 +6,3 @@ west espressif update
 west espressif install
 ```
 
-:::caution
-Older versions of the Zephyr SDK Toolchain (prior to 0.14.2) installed the compiler tools using `west espressif install` and required manually setting environmental variables as follows:
-
-```shell
-set ESPRESSIF_TOOLCHAIN_PATH=C:\Users\Mike\.espressif\tools\zephyr
-set ZEPHYR_TOOLCHAIN_VARIANT=espressif
-```
-
-Now, compiler tools are included in the Zephyr SDK. Manually setting these environmental variables is deprecated and this step is no longer needed. We included this message to help inform users about the changes.
-:::


### PR DESCRIPTION
Users have not needed to set env vars for ESP32 since May 14. Removed
this warning as it is no longer likely to be useful.