### PR TITLE
treewide: fix 'LightDB' and 'LightDB Stream' spelling

### DIFF
--- a/docs/cloud/1-services/4-lightdb-stream/3-querying-data.md
+++ b/docs/cloud/1-services/4-lightdb-stream/3-querying-data.md
@@ -79,7 +79,7 @@ Let's define our first query to get just the raw data on the last 8h and where t
 }
 ```
 
-Let's save that into a file called query.json and use that to query the LightDB stream. You can use the REST API, which is more configurable, but goliothctl works great for simple cases like this.
+Let's save that into a file called query.json and use that to query the LightDB Stream. You can use the REST API, which is more configurable, but goliothctl works great for simple cases like this.
 
 ```
 ❯ cat query.json | goliothctl stream query --interval 8h --in | jq .

--- a/docs/cloud/1-services/4-lightdb-stream/README.md
+++ b/docs/cloud/1-services/4-lightdb-stream/README.md
@@ -6,7 +6,7 @@ slug: /cloud/services/lightdb-stream
 
 ## What is LightDB Stream?
 
-A LightDB Stream is just that, the concept of LightDB applied to streamed, timeseries data. Instead of a single value, with the most recent data taking precedence, LightDB Streams are append-only and store all data that's ever been submitted, in order of timestamp.
+A LightDB Stream is just that, the concept of LightDB applied to streamed, timeseries data. Instead of a single value, with the most recent data taking precedence, LightDB Stream is append-only and store all data that's ever been submitted, in order of timestamp.
 
 LightDB Stream queries are highly configurable, supporting field subsets, aggregation, and multiple devices at once.
 

--- a/docs/firmware/firmware-client-auth.drawio.svg
+++ b/docs/firmware/firmware-client-auth.drawio.svg
@@ -300,13 +300,13 @@
                     <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 49px; height: 1px; padding-top: 469px; margin-left: 84px;">
                         <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
                             <div style="display: inline-block; font-size: 10px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: none; font-weight: bold; white-space: normal; word-wrap: normal; ">
-                                Light DB
+                                LightDB
                             </div>
                         </div>
                     </div>
                 </foreignObject>
                 <text x="108" y="472" fill="#000000" font-family="Helvetica" font-size="10px" text-anchor="middle" font-weight="bold">
-                    Light DB
+                    LightDB
                 </text>
             </switch>
         </g>
@@ -317,13 +317,13 @@
                     <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 55px; height: 1px; padding-top: 469px; margin-left: 141px;">
                         <div style="box-sizing: border-box; font-size: 0; text-align: center; ">
                             <div style="display: inline-block; font-size: 10px; font-family: Helvetica; color: #000000; line-height: 1.2; pointer-events: none; font-weight: bold; white-space: normal; word-wrap: normal; ">
-                                Light DB Stream
+                                LightDB Stream
                             </div>
                         </div>
                     </div>
                 </foreignObject>
                 <text x="169" y="472" fill="#000000" font-family="Helvetica" font-size="10px" text-anchor="middle" font-weight="bold">
-                    Light DB St...
+                    LightDB St...
                 </text>
             </switch>
         </g>

--- a/docs/getting-started/2-console/1-overview.md
+++ b/docs/getting-started/2-console/1-overview.md
@@ -8,7 +8,7 @@ The Golioth Console provides a web-based configuration tool for managing your de
 
 * Create and manage projects
 * Provision your fleet of hardware, organized by projects and tags
-* View and query device logs and LightDB Streams
+* View and query device logs and LightDB Stream
 * View and change persistent data in LightDB
 * Manage Over-the-Air (OTA) updates for firmware and other assets
 * Manage API keys (REST, WebSockets, etc.)

--- a/docs/getting-started/2-console/1-overview.md
+++ b/docs/getting-started/2-console/1-overview.md
@@ -8,7 +8,7 @@ The Golioth Console provides a web-based configuration tool for managing your de
 
 * Create and manage projects
 * Provision your fleet of hardware, organized by projects and tags
-* View and query device logs and LightDB streams
+* View and query device logs and LightDB Streams
 * View and change persistent data in LightDB
 * Manage Over-the-Air (OTA) updates for firmware and other assets
 * Manage API keys (REST, WebSockets, etc.)

--- a/docs/reference/5-command-line-tools/1-goliothctl/goliothctl.md
+++ b/docs/reference/5-command-line-tools/1-goliothctl/goliothctl.md
@@ -50,7 +50,7 @@ goliothctl provision --hwId "DE:AD:BE:EF" --name "My first device" --credId "dea
 * [goliothctl config](/reference/command-line-tools/goliothctl/goliothctl_config/)	 - The `goliothctl config` subcommands are used to get and set values in the current local goliothctl config.
 * [goliothctl device](/reference/command-line-tools/goliothctl/goliothctl_device/)	 - Use the `goliothctl device` subcommands to add, remove, list, and update data associated with devices.
 * [goliothctl dfu](/reference/command-line-tools/goliothctl/goliothctl_dfu/)	 - Firmware management command.
-* [goliothctl lightdb](/reference/command-line-tools/goliothctl/goliothctl_lightdb/)	 - Access data on Light DB
+* [goliothctl lightdb](/reference/command-line-tools/goliothctl/goliothctl_lightdb/)	 - Access data on LightDB
 * [goliothctl login](/reference/command-line-tools/goliothctl/goliothctl_login/)	 - Authenticate with Golioth.
 * [goliothctl logout](/reference/command-line-tools/goliothctl/goliothctl_logout/)	 - Log out of Golioth manually.
 * [goliothctl logs](/reference/command-line-tools/goliothctl/goliothctl_logs/)	 - Show device logs (from the last 4h by default)

--- a/docs/reference/5-command-line-tools/1-goliothctl/goliothctl_device_list.md
+++ b/docs/reference/5-command-line-tools/1-goliothctl/goliothctl_device_list.md
@@ -39,7 +39,7 @@ id:"60abc24dad0772e87bb232f4"  hardware_ids:"serialNumber2"  name:"Test Device 2
       --hwId stringArray   device hardware id
       --name string        device name
       --state string       LightDB state path
-      --stream string      LightDB stream latest path
+      --stream string      LightDB Stream latest path
       --tags stringArray   tag names
       --term string        term to find devices through partial string match
       --update string      LightDB update state path

--- a/docs/reference/5-command-line-tools/1-goliothctl/goliothctl_lightdb.md
+++ b/docs/reference/5-command-line-tools/1-goliothctl/goliothctl_lightdb.md
@@ -8,7 +8,7 @@ hide_title: true
 ---
 ## goliothctl lightdb
 
-Access data on Light DB
+Access data on LightDB
 
 ```
 goliothctl lightdb [flags]

--- a/docs/reference/5-command-line-tools/1-goliothctl/goliothctl_lightdb_delete.md
+++ b/docs/reference/5-command-line-tools/1-goliothctl/goliothctl_lightdb_delete.md
@@ -33,5 +33,5 @@ goliothctl lightdb delete [device name] <path> [flags]
 
 ### SEE ALSO
 
-* [goliothctl lightdb](/reference/command-line-tools/goliothctl/goliothctl_lightdb/)	 - Access data on Light DB
+* [goliothctl lightdb](/reference/command-line-tools/goliothctl/goliothctl_lightdb/)	 - Access data on LightDB
 

--- a/docs/reference/5-command-line-tools/1-goliothctl/goliothctl_lightdb_get.md
+++ b/docs/reference/5-command-line-tools/1-goliothctl/goliothctl_lightdb_get.md
@@ -32,5 +32,5 @@ goliothctl lightdb get [device name] <path> [flags]
 
 ### SEE ALSO
 
-* [goliothctl lightdb](/reference/command-line-tools/goliothctl/goliothctl_lightdb/)	 - Access data on Light DB
+* [goliothctl lightdb](/reference/command-line-tools/goliothctl/goliothctl_lightdb/)	 - Access data on LightDB
 

--- a/docs/reference/5-command-line-tools/1-goliothctl/goliothctl_lightdb_listen.md
+++ b/docs/reference/5-command-line-tools/1-goliothctl/goliothctl_lightdb_listen.md
@@ -48,4 +48,4 @@ goliothctl lightdb listen [flags] <path>
 
 ### SEE ALSO
 
-* [goliothctl lightdb](/reference/command-line-tools/goliothctl/goliothctl_lightdb/) - Access data on Light DB
+* [goliothctl lightdb](/reference/command-line-tools/goliothctl/goliothctl_lightdb/) - Access data on LightDB

--- a/docs/reference/5-command-line-tools/1-goliothctl/goliothctl_lightdb_set.md
+++ b/docs/reference/5-command-line-tools/1-goliothctl/goliothctl_lightdb_set.md
@@ -37,5 +37,5 @@ goliothctl lightdb set [device name] <path> [flags]
 
 ### SEE ALSO
 
-* [goliothctl lightdb](/reference/command-line-tools/goliothctl/goliothctl_lightdb/)	 - Access data on Light DB
+* [goliothctl lightdb](/reference/command-line-tools/goliothctl/goliothctl_lightdb/)	 - Access data on LightDB
 

--- a/docs/reference/5-command-line-tools/1-goliothctl/goliothctl_stream.md
+++ b/docs/reference/5-command-line-tools/1-goliothctl/goliothctl_stream.md
@@ -68,5 +68,5 @@ $ goliothctl stream listen [device name]
 
 * [goliothctl](/reference/command-line-tools/goliothctl/goliothctl/)	 - Manage Golioth platform resources and developer workflow.
 * [goliothctl stream get](/reference/command-line-tools/goliothctl/goliothctl_stream_get/)	 - Get latest stream data at given path.
-* [goliothctl stream query](/reference/command-line-tools/goliothctl/goliothctl_stream_query/)	 - Run a query against all data stored in a LightDB stream in the supplied path.
+* [goliothctl stream query](/reference/command-line-tools/goliothctl/goliothctl_stream_query/)	 - Run a query against all data stored in a LightDB Stream in the supplied path.
 * [goliothctl stream listen](/reference/command-line-tools/goliothctl/goliothctl_stream_listen/)	 - Listen to streams

--- a/docs/reference/5-command-line-tools/1-goliothctl/goliothctl_stream_query.md
+++ b/docs/reference/5-command-line-tools/1-goliothctl/goliothctl_stream_query.md
@@ -8,7 +8,7 @@ hide_title: true
 ---
 ## goliothctl stream query
 
-Run a query against all data stored in a LightDB stream in the supplied path.
+Run a query against all data stored in a LightDB Stream in the supplied path.
 
 ```
 goliothctl stream query [flags]


### PR DESCRIPTION
Following commands were executed in root directory:

```
  $ sed -i 's/Light DB/LightDB/g' `find -type f`
  $ sed -i 's/LightDB stream/LightDB Stream/g' `find -type f`
  $ sed -i 's/LightDB Streams/LightDB Stream/g' `find -type f 
```
with some manual adjustments.