### PR TITLE
Fix: missed name change for QEMU level

### DIFF
--- a/scripts/device-catalog/support.json
+++ b/scripts/device-catalog/support.json
@@ -14,7 +14,7 @@
       "quickstart": "/hardware/virtual-devices/zephyr-quickstart"
     },
     "qemu_x86": {
-      "level": "quickstart",
+      "level": "continuously-verified",
       "quickstart": "/hardware/virtual-devices/zephyr-quickstart"
     }
   },


### PR DESCRIPTION
This should have been in #219 