### PR TITLE
Update Zephyr SDK to v0.15.0

### DIFF
--- a/docs/hardware/2-esp32/2-zephyr-quickstart/2-set-up-zephyr.md
+++ b/docs/hardware/2-esp32/2-zephyr-quickstart/2-set-up-zephyr.md
@@ -26,7 +26,7 @@ import InstallZephyrSDKtoolchain from '/docs/partials/install-zephyr-sdk-toolcha
 
 <InstallZephyrSDKtoolchain/>
 
-### Install the Espressif (ESP32) submodules
+### Install Espressif (ESP32) Binary Blobs
 
 import InstallEspressifToolchain from '/docs/partials/install-espressif-toolchain.md'
 

--- a/docs/partials/install-espressif-toolchain-unix.md
+++ b/docs/partials/install-espressif-toolchain-unix.md
@@ -3,6 +3,5 @@
 ```shell
 cd ~/golioth-zephyr-workspace
 west espressif update
-west espressif install
 ```
 

--- a/docs/partials/install-espressif-toolchain-unix.md
+++ b/docs/partials/install-espressif-toolchain-unix.md
@@ -1,7 +1,7 @@
-`west` makes it easy to install Espressif submodules and OpenOCD configurations:
+Use `west` to install the WiFi and Bluetooth binary blobs necessary for building Espressif projects.
 
 ```shell
 cd ~/golioth-zephyr-workspace
-west espressif update
+west blobs fetch hal_espressif
 ```
 

--- a/docs/partials/install-espressif-toolchain-windows.md
+++ b/docs/partials/install-espressif-toolchain-windows.md
@@ -1,7 +1,7 @@
-`west` makes it easy to install Espressif submodules and OpenOCD configurations:
+Use `west` to install the WiFi and Bluetooth binary blobs necessary for building Espressif projects.
 
 ```shell
 cd c:\golioth-zephyr-workspace
-west espressif update
+west blobs fetch hal_espressif
 ```
 

--- a/docs/partials/install-espressif-toolchain-windows.md
+++ b/docs/partials/install-espressif-toolchain-windows.md
@@ -3,6 +3,5 @@
 ```shell
 cd c:\golioth-zephyr-workspace
 west espressif update
-west espressif install
 ```
 

--- a/docs/partials/install-zephyr-sdk-toolchain.md
+++ b/docs/partials/install-zephyr-sdk-toolchain.md
@@ -15,14 +15,14 @@ values={[
 
 ```console
 cd ~
-wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.14.2/zephyr-sdk-0.14.2_linux-x86_64.tar.gz
+wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.15.0/zephyr-sdk-0.15.0_linux-x86_64.tar.gz
 ```
 
-Unpack the archive and run the installer. The SDK will be placed in the `~/zephyr-sdk-0.14.2` directory:
+Unpack the archive and run the installer. The SDK will be placed in the `~/zephyr-sdk-0.15.0` directory:
 
 ```console
-tar -xvf zephyr-sdk-0.14.2_linux-x86_64.tar.gz
-cd zephyr-sdk-0.14.2
+tar -xvf zephyr-sdk-0.15.0_linux-x86_64.tar.gz
+cd zephyr-sdk-0.15.0
 ./setup.sh
 ```
 
@@ -31,7 +31,7 @@ Answer `y` to both of the questions asked during the setup process.
 Install udev rules, which allow you to flash most Zephyr boards as a regular user:
 
 ```console
-sudo cp ~/zephyr-sdk-0.14.2/sysroots/x86_64-pokysdk-linux/usr/share/openocd/contrib/60-openocd.rules /etc/udev/rules.d/
+sudo cp ~/zephyr-sdk-0.15.0/sysroots/x86_64-pokysdk-linux/usr/share/openocd/contrib/60-openocd.rules /etc/udev/rules.d
 sudo udevadm control --reload
 ```
 
@@ -40,14 +40,14 @@ sudo udevadm control --reload
 
 ```console
 cd ~
-wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.14.2/zephyr-sdk-0.14.2_macos-x86_64.tar.gz
+wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.15.0/zephyr-sdk-0.15.0_macos-x86_64.tar.gz
 ```
 
-Unpack the archive and run the installer. The SDK will be placed in the `~/zephyr-sdk-0.14.2` directory:
+Unpack the archive and run the installer. The SDK will be placed in the `~/zephyr-sdk-0.15.0` directory:
 
 ```console
-tar -xvf zephyr-sdk-0.14.2_macos-x86_64.tar.gz
-cd zephyr-sdk-0.14.2
+tar -xvf zephyr-sdk-0.15.0_macos-x86_64.tar.gz
+cd zephyr-sdk-0.15.0
 ./setup.sh
 ```
 
@@ -58,9 +58,9 @@ Unpack the archive and run the installer. The SDK will be placed in the `%HOMEPA
 
 ```console
 cd %HOMEPATH%
-wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.14.2/zephyr-sdk-0.14.2_windows-x86_64.zip
-unzip zephyr-sdk-0.14.2_windows-x86_64.zip
-cd zephyr-sdk-0.14.2
+wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.15.0/zephyr-sdk-0.15.0_windows-x86_64.zip
+unzip zephyr-sdk-0.15.0_windows-x86_64.zip
+cd zephyr-sdk-0.15.0
 setup.cmd
 ```
 


### PR DESCRIPTION
Update download links and instructions for Zephyr SDK 0.15.0 Change west espressif update/install to west blob command

Signed-off-by: Mike Szczys <mike@golioth.io>