### PR TITLE
hardware: fix board name in sample build code

### DIFF
--- a/docs/hardware/2-esp32/2-zephyr-quickstart/2-set-up-zephyr.md
+++ b/docs/hardware/2-esp32/2-zephyr-quickstart/2-set-up-zephyr.md
@@ -36,39 +36,6 @@ import InstallEspressifToolchain from '/docs/partials/install-espressif-toolchai
 
 Your system is all set up and ready to start building & flashing with Zephyr. Verify by building a minimal sample:
 
-<Tabs
-groupId="os"
-defaultValue="linux"
-values={[
-{label: 'Linux', value: 'linux'},
-{label: 'MacOS', value: 'macos'},
-{label: 'Windows', value: 'windows'},
-]}>
+import BuildSample from '/docs/partials/sample-build.mdx'
 
-<TabItem value="linux">
-
-```shell
-cd ~/golioth-zephyr-workspace/zephyr
-west build -b esp32 samples/basic/minimal -p
-```
-
-</TabItem>
-<TabItem value="macos">
-
-```shell
-cd ~/golioth-zephyr-workspace/zephyr
-west build -b esp32 samples/basic/minimal -p
-```
-
-</TabItem>
-<TabItem value="windows">
-
-1. Verify by building a minimal sample:
-
-    ```shell
-    cd C:\golioth-zephyr-workspace\zephyr
-    west build -b esp32 samples\basic\minimal -p
-    ```
-
-</TabItem>
-</Tabs>
+<BuildSample board="esp32"/>

--- a/docs/hardware/3-mimxrt1060_evkb/1-zephyr-quickstart/2-set-up-zephyr.md
+++ b/docs/hardware/3-mimxrt1060_evkb/1-zephyr-quickstart/2-set-up-zephyr.md
@@ -30,39 +30,6 @@ import InstallZephyrSDKtoolchain from '/docs/partials/install-zephyr-sdk-toolcha
 
 Your system is all set up and ready to start building & flashing with Zephyr. Verify by building a minimal sample:
 
-<Tabs
-groupId="os"
-defaultValue="linux"
-values={[
-{label: 'Linux', value: 'linux'},
-{label: 'MacOS', value: 'macos'},
-{label: 'Windows', value: 'windows'},
-]}>
+import BuildSample from '/docs/partials/sample-build.mdx'
 
-<TabItem value="linux">
-
-```shell
-cd ~/golioth-zephyr-workspace/zephyr
-west build -b esp32 samples/basic/minimal -p
-```
-
-</TabItem>
-<TabItem value="macos">
-
-```shell
-cd ~/golioth-zephyr-workspace/zephyr
-west build -b esp32 samples/basic/minimal -p
-```
-
-</TabItem>
-<TabItem value="windows">
-
-1. Verify by building a minimal sample:
-
-    ```shell
-    cd C:\golioth-zephyr-workspace\zephyr
-    west build -b esp32 samples\basic\minimal -p
-    ```
-
-</TabItem>
-</Tabs>
+<BuildSample board="mimxrt1060_evkb"/>

--- a/docs/partials/sample-build.mdx
+++ b/docs/partials/sample-build.mdx
@@ -1,0 +1,38 @@
+import CodeBlock from '@theme/CodeBlock';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs
+groupId="os"
+defaultValue="linux"
+values={[
+{label: 'Linux', value: 'linux'},
+{label: 'MacOS', value: 'macos'},
+{label: 'Windows', value: 'windows'},
+]}>
+
+<TabItem value="linux">
+
+<CodeBlock language="bash">
+cd ~/golioth-zephyr-workspace/zephyr<br />
+west build -b {props.board} samples/basic/minimal -p
+</CodeBlock>
+
+</TabItem>
+<TabItem value="macos">
+
+<CodeBlock language="bash">
+cd ~/golioth-zephyr-workspace/zephyr<br />
+west build -b {props.board} samples/basic/minimal -p
+</CodeBlock>
+
+</TabItem>
+<TabItem value="windows">
+
+<CodeBlock language="bash">
+cd C:\golioth-zephyr-workspace\zephyr<br />
+west build -b {props.board} samples\basic\minimal -p
+</CodeBlock>
+
+</TabItem>
+</Tabs>


### PR DESCRIPTION
Abstract the sample build section of Setup Zephyr pages so it can be reused with a different board name as a property of the import.

Signed-off-by: Mike Szczys <mike@golioth.io>