### PR TITLE
esp-idf install: remove erroneous import

### DIFF
--- a/docs/partials/espidf/install-espidf.md
+++ b/docs/partials/espidf/install-espidf.md
@@ -33,8 +33,6 @@ git submodule update --init --recursive
 ./install.sh all
 ```
 
-<SetupZephyrUnix />
-
 </TabItem>
 <TabItem value="macos">
 
@@ -59,8 +57,6 @@ git checkout v4.4.1
 git submodule update --init --recursive
 ./install.sh all
 ```
-
-<SetupZephyrUnix />
 
 </TabItem>
 <TabItem value="windows">


### PR DESCRIPTION
Fixes the following warnings:

Component SetupZephyrUnix was not imported, exported, or provided by MDXProvider as global scope

Signed-off-by: Mike Szczys <mike@golioth.io>