### PR TITLE
MQTT: topic paths do not begin with a /

### DIFF
--- a/docs/reference/2-protocols/2-mqtt/3-lightdb.md
+++ b/docs/reference/2-protocols/2-mqtt/3-lightdb.md
@@ -11,17 +11,17 @@ How to use guides:
 
 ### Interface
 
-| Method    | Description                  | Path            | Content Format |
-| --------- | ---------------------------- | --------------- | -------------- |
-| Subscribe | Read persisted data          | /.d/{path=\*\*} | JSON           |
-| Publish   | Create/Update data           | /.d/{path=\*\*} | JSON           |
-| Publish   | Delete Data if body is empty | /.d/{path=\*\*} | JSON           |
+| Method    | Description                  | Path           | Content Format |
+| --------- | ---------------------------- | -------------- | -------------- |
+| Subscribe | Read persisted data          | .d/{path=\*\*} | JSON           |
+| Publish   | Create/Update data           | .d/{path=\*\*} | JSON           |
+| Publish   | Delete Data if body is empty | .d/{path=\*\*} | JSON           |
 
 > `path` can be any valid URI sub path. Ex:
 >
-> /.d/temp/state
+> .d/temp/state
 >
-> /.d/temp/active
+> .d/temp/active
 
 The body can be a JSON object or a single value in the following formats:
 

--- a/docs/reference/2-protocols/2-mqtt/4-lightdb-stream.md
+++ b/docs/reference/2-protocols/2-mqtt/4-lightdb-stream.md
@@ -11,16 +11,16 @@ How to use guides:
 
 ### Interface
 
-| Method    | Description     | Path            | Content Format |
-| --------- | --------------- | --------------- | -------------- |
-| Publish   | Send data       | /.s/{path=\*\*} | JSON           |
-| Subscribe | Get latest data | /.s/{path=\*\*} | JSON           |
+| Method    | Description     | Path           | Content Format |
+| --------- | --------------- | -------------- | -------------- |
+| Publish   | Send data       | .s/{path=\*\*} | JSON           |
+| Subscribe | Get latest data | .s/{path=\*\*} | JSON           |
 
 > `path` can be any valid URI sub path. Ex:
 >
-> /.s/env/temperature
+> .s/env/temperature
 >
-> /.s/location
+> .s/location
 
 To demonstrate the operations here, let's imagine that we are tracking an asset using an IoT device. The location data from our device is going to periodically pushed to a LightDB Stream.
 

--- a/docs/reference/2-protocols/2-mqtt/5-logging.md
+++ b/docs/reference/2-protocols/2-mqtt/5-logging.md
@@ -11,9 +11,9 @@ How to use guides:
 
 ### Interface
 
-| Method  | Description | Path  | Content Format |
-| ------- | ----------- | ----- | -------------- |
-| Publish | Send logs   | /logs | JSON           |
+| Method  | Description | Path | Content Format |
+| ------- | ----------- | ---- | -------------- |
+| Publish | Send logs   | logs | JSON           |
 
 ### Parameters and attributes that are known and indexed:
 

--- a/docs/reference/2-protocols/2-mqtt/6-ota.md
+++ b/docs/reference/2-protocols/2-mqtt/6-ota.md
@@ -11,11 +11,11 @@ How to use guides:
 
 ### Interface
 
-| Method    | Description                                      | Path                      |
-| --------- | ------------------------------------------------ | ------------------------- |
-| Subscribe | Get desired release version in Manifest Format   | /.u/desired               |
-| Subscribe | Download binary of a given component and version | /.u/c/{package}@{version} |
-| Publish   | Report firmware state for a given package        | /.u/c/{package}           |
+| Method    | Description                                      | Path                     |
+| --------- | ------------------------------------------------ | ------------------------ |
+| Subscribe | Get desired release version in Manifest Format   | .u/desired               |
+| Subscribe | Download binary of a given component and version | .u/c/{package}@{version} |
+| Publish   | Report firmware state for a given package        | .u/c/{package}           |
 
 ### Release Manifest Format
 


### PR DESCRIPTION
MQTT topics do not typically begin with a `/`, even if it is a [common misunderstanding](https://www.hivemq.com/blog/mqtt-essentials-part-5-mqtt-topics-best-practices/):

> ### Never use a leading forward slash
>
> A leading forward slash is permitted in MQTT. For example, `/myhome/groundfloor/livingroom`. However, the leading forward slash introduces an unnecessary topic level with a zero character at the front. The zero does not provide any benefit and often leads to confusion.

I verified that your implementation just trims the leading slash under the hood, so it sounds best to just not recommend using it.