### PR TITLE
Remove MQTT Stream sub example

### DIFF
--- a/docs/reference/2-protocols/2-mqtt/4-lightdb-stream.md
+++ b/docs/reference/2-protocols/2-mqtt/4-lightdb-stream.md
@@ -14,7 +14,6 @@ How to use guides:
 | Method    | Description     | Path           | Content Format |
 | --------- | --------------- | -------------- | -------------- |
 | Publish   | Send data       | .s/{path=\*\*} | JSON           |
-| Subscribe | Get latest data | .s/{path=\*\*} | JSON           |
 
 > `path` can be any valid URI sub path. Ex:
 >


### PR DESCRIPTION
MQTT Stream implementation is write-only. This commit removes the mention of an endpoint to subscribe to a stream.