### PR TITLE
replace golioth-esp-idf-sdk with golioth-firmware-sdk

### DIFF
--- a/docs/hardware/2-esp32/1-espidf-quickstart/2-set-up-espidf.md
+++ b/docs/hardware/2-esp32/1-espidf-quickstart/2-set-up-espidf.md
@@ -6,10 +6,10 @@ title: Set up ESP-IDF for ESP32
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-The [Golioth ESP-IDF SDK](https://github.com/golioth/golioth-esp-idf-sdk) can be
+The [Golioth Firmware SDK](https://github.com/golioth/golioth-firmware-sdk) can be
 installed as a component of the ESP-IDF. This delivers a set of APIs that let
 you use Golioth with any ESP-IDF based projects. This guide will walk through
-the process of installing both the ESP-IDF and the Golioth ESP-IDF SDK.
+the process of installing both the ESP-IDF and the Golioth Firmware SDK.
 
 ### Install ESP-IDF
 
@@ -17,11 +17,11 @@ import SetupEspIdf from '/docs/partials/espidf/install-espidf.md'
 
 <SetupEspIdf/>
 
-### Install Golioth ESP-IDF SDK
+### Install Golioth Firmware SDK
 
-import InstallEspIdfSDK from '/docs/partials/espidf/install-golioth-espidf-sdk.md'
+import InstallFirmwareSDK from '/docs/partials/espidf/install-golioth-firmware-sdk.md'
 
-<InstallEspIdfSDK/>
+<InstallFirmwareSDK/>
 
 ### Set the ESP IDF environment variables
 

--- a/docs/hardware/2-esp32/1-espidf-quickstart/3-flash-sample.md
+++ b/docs/hardware/2-esp32/1-espidf-quickstart/3-flash-sample.md
@@ -9,8 +9,8 @@ demonstrate core features like LightDB State/Stream, Logging, and OTA Updates.
 
 ### Build the `golioth_basics` code example
 
-Golioth ESP-IDF SDK example code is located in the
-`golioth-esp-idf-sdk/examples`. Navigate to the `golioth_basics` example and run
+Golioth Firmware SDK example code is located in the
+`golioth-firmware-sdk/examples/esp_idf`. Navigate to the `golioth_basics` example and run
 the following code to build the example app:
 
 ```console

--- a/docs/hardware/2-esp32/1-espidf-quickstart/README.md
+++ b/docs/hardware/2-esp32/1-espidf-quickstart/README.md
@@ -12,6 +12,6 @@ This walk-through will demonstrate how to quickly connect an Espressif [ESP32 De
 
 :::note
 
-[Golioth's ESP-IDF SDK](https://github.com/golioth/golioth-esp-idf-sdk) will work with other ESP32 devkits. We're using the DevKitC as a reference board to provide a consistent getting started experience.
+[Golioth's Firmware SDK](https://github.com/golioth/golioth-firmware-sdk) will work with other ESP32 devkits. We're using the DevKitC as a reference board to provide a consistent getting started experience.
 
 :::

--- a/docs/partials/espidf/install-golioth-firmware-sdk.md
+++ b/docs/partials/espidf/install-golioth-firmware-sdk.md
@@ -12,12 +12,12 @@ values={[
 
 <TabItem value="linux">
 
-#### 1. Clone the Golioth ESP-IDF SDK repository and update submodules
+#### 1. Clone the Golioth Firmware SDK repository and update submodules
 
 ```console
 cd ~
-git clone --recursive https://github.com/golioth/golioth-esp-idf-sdk.git
-cd golioth-esp-idf-sdk
+git clone --recursive https://github.com/golioth/golioth-firmware-sdk.git
+cd golioth-firmware-sdk
 git submodule update --init --recursive
 ```
 
@@ -25,12 +25,12 @@ git submodule update --init --recursive
 
 <TabItem value="macos">
 
-#### 1. Clone the Golioth ESP-IDF SDK repository and update submodules
+#### 1. Clone the Golioth Firmware SDK repository and update submodules
 
 ```console
 cd ~
-git clone --recursive https://github.com/golioth/golioth-esp-idf-sdk.git
-cd golioth-esp-idf-sdk
+git clone --recursive https://github.com/golioth/golioth-firmware-sdk.git
+cd golioth-firmware-sdk
 git submodule update --init --recursive
 ```
 
@@ -38,12 +38,12 @@ git submodule update --init --recursive
 
 <TabItem value="windows">
 
-#### 1. Clone the Golioth ESP-IDF SDK repository and update submodules
+#### 1. Clone the Golioth Firmware SDK repository and update submodules
 
 ```console
 cd %HOMEPATH%
-git clone --recursive https://github.com/golioth/golioth-esp-idf-sdk.git
-cd golioth-esp-idf-sdk
+git clone --recursive https://github.com/golioth/golioth-firmware-sdk.git
+cd golioth-firmware-sdk
 git submodule update --init --recursive
 ```
 

--- a/docs/reference/1-home.md
+++ b/docs/reference/1-home.md
@@ -16,5 +16,5 @@ The API and SDK reference documentation provides detailed information for each o
   - [goliothctl](/reference/command-line-tools/goliothctl/goliothctl/)
   - [coap](/reference/command-line-tools/coap/coap/)
 - Device SDKs
-  - [Golioth ESP-IDF SDK Reference](/reference/device-sdks/golioth-esp-idf-sdk)
+  - [Golioth Firmware SDK Reference](/reference/device-sdks/golioth-firmware-sdk)
   - [Golioth Zephyr SDK Reference](/reference/device-sdks/golioth-zephyr-sdk)

--- a/docs/reference/6-device-sdks/1-esp-idf-sdk.md
+++ b/docs/reference/6-device-sdks/1-esp-idf-sdk.md
@@ -1,8 +1,0 @@
----
-id: golioth-esp-idf-sdk
-title: Golioth ESP-IDF SDK
----
-
-The documentation for the [Golioth ESP-IDF SDK](https://github.com/golioth/golioth-esp-idf-sdk/) is automatically generated using Doxygen and can be view at our external reference site:
-
-* [Golioth ESP-IDF SDK Doxygen Reference](https://esp-idf-sdk-docs.golioth.io/)

--- a/docs/reference/6-device-sdks/1-firmware-sdk.md
+++ b/docs/reference/6-device-sdks/1-firmware-sdk.md
@@ -1,0 +1,8 @@
+---
+id: golioth-firmware-sdk
+title: Golioth Firmware SDK
+---
+
+The documentation for the [Golioth Firmware SDK](https://github.com/golioth/golioth-firmware-sdk/) is automatically generated using Doxygen and can be view at our external reference site:
+
+* [Golioth Firmware SDK Doxygen Reference](https://firmware-sdk-docs.golioth.io/)


### PR DESCRIPTION
The intent is to direct ESP-IDF users to the cross-platform firmware SDK. The prior golioth-esp-idf-sdk repo is being deprecated.

Signed-off-by: Nick Miller <nick@golioth.io>