### PR TITLE
coap limitations: rename page, add payload limit

### DIFF
--- a/docs/reference/2-protocols/1-coap/7-limits.md
+++ b/docs/reference/2-protocols/1-coap/7-limits.md
@@ -1,7 +1,9 @@
 ---
 id: limits
-title: CoAP Request Limits
+title: CoAP Limitations
 ---
+
+## Requests per device
 
 Golioth servers enforce the following limit on CoAP requests:
 
@@ -13,3 +15,10 @@ service](/cloud/services/lightdb-stream/sending-data), your device can add
 timestamps to data packets by using `t`, `ts`, or `time` as the key. The Golioth
 LightDB Stream service will use the timestamp for the database entry instead of
 the time received.
+
+## Payload length
+
+We recommend that you limit your payload length to 1024 bytes. The
+expected result of sending larger payloads is [IP
+fragmentation](https://en.wikipedia.org/wiki/IP_fragmentation) which may result
+in unwanted retransmissions.


### PR DESCRIPTION
Generalizes name to CoAP LImits and adds section about payload length.