### PR TITLE
Include required CONFIG | qemu_cortex_m3 | hello | build

### DIFF
--- a/docs/hardware/5-virtual-device/2-zephyr-quickstart/5-simulating-devices-qemu.md
+++ b/docs/hardware/5-virtual-device/2-zephyr-quickstart/5-simulating-devices-qemu.md
@@ -41,6 +41,10 @@ At the bottom of the page, add your credentials for your device:
 ```
 CONFIG_GOLIOTH_SYSTEM_CLIENT_PSK_ID="DEVICE_CRED_ID"
 CONFIG_GOLIOTH_SYSTEM_CLIENT_PSK="DEVICE_PSK"
+
+# May be required to address undefined references to functions
+CONFIG_ENTROPY_GENERATOR=y
+CONFIG_TEST_RANDOM_GENERATOR=y
 ```
 Save and exit (`ctrl+x` in nano)
 


### PR DESCRIPTION
Fix Reference: https://github.com/zephyrproject-rtos/zephyr/issues/15565

Steps to reproduce
1. Go through [steps](https://docs.golioth.io/hardware/virtual-device/zephyr-quickstart/simulating-devices-qemu) leading up to `west build -b qemu_cortex_m3 samples/hello -p`
2. 
```
cd ~/west build -b qemu_cortex_m3 samples/hello -p
west build -b qemu_cortex_m3 samples/hello -p
```


## Failing Build

While going through documentation using a venv I encuntered this error when building for `qemu_cortex_m3` for the sample `hello`

```
(.venv) ➜  golioth git:(main) ✗ west build -b qemu_cortex_m3 samples/hello -p
-- west build: making build dir /home/ian/golioth-zephyr-workspace/modules/lib/golioth/build pristine
-- west build: generating a build system
Loading Zephyr default modules (Zephyr base).
-- Application: /home/ian/golioth-zephyr-workspace/modules/lib/golioth/samples/hello
-- Found Python3: /home/ian/golioth-zephyr-workspace/.venv/bin/python3 (found suitable exact version "3.8.10") found components: Interpreter 
-- Cache files will be written to: /home/ian/.cache/zephyr
-- Zephyr version: 3.2.0 (/home/ian/golioth-zephyr-workspace/zephyr)
-- Found west (found suitable version "0.14.0", minimum required is "0.7.1")
-- Board: qemu_cortex_m3
-- Found host-tools: zephyr 0.15.2 (/home/ian/zephyr-sdk-0.15.2)
-- Found toolchain: zephyr 0.15.2 (/home/ian/zephyr-sdk-0.15.2)
-- Found Dtc: /home/ian/zephyr-sdk-0.15.2/sysroots/x86_64-pokysdk-linux/usr/bin/dtc (found suitable version "1.6.0", minimum required is "1.4.6") 
-- Found BOARD.dts: /home/ian/golioth-zephyr-workspace/zephyr/boards/arm/qemu_cortex_m3/qemu_cortex_m3.dts
-- Generated zephyr.dts: /home/ian/golioth-zephyr-workspace/modules/lib/golioth/build/zephyr/zephyr.dts
-- Generated devicetree_generated.h: /home/ian/golioth-zephyr-workspace/modules/lib/golioth/build/zephyr/include/generated/devicetree_generated.h
-- Including generated dts.cmake file: /home/ian/golioth-zephyr-workspace/modules/lib/golioth/build/zephyr/dts.cmake
Parsing /home/ian/golioth-zephyr-workspace/modules/lib/golioth/samples/hello/Kconfig
Loaded configuration '/home/ian/golioth-zephyr-workspace/zephyr/boards/arm/qemu_cortex_m3/qemu_cortex_m3_defconfig'
Merged configuration '/home/ian/golioth-zephyr-workspace/modules/lib/golioth/samples/hello/prj.conf'
Configuration saved to '/home/ian/golioth-zephyr-workspace/modules/lib/golioth/build/zephyr/.config'
Kconfig header saved to '/home/ian/golioth-zephyr-workspace/modules/lib/golioth/build/zephyr/include/generated/autoconf.h'

warning: QEMU_ICOUNT_SHIFT (defined at boards/Kconfig:67) was assigned the value '6' but got the
value ''. Check these unsatisfied dependencies: QEMU_ICOUNT (=n). See
http://docs.zephyrproject.org/latest/kconfig.html#CONFIG_QEMU_ICOUNT_SHIFT and/or look up
QEMU_ICOUNT_SHIFT in the menuconfig/guiconfig interface. The Application Development Primer, Setting
Configuration Values, and Kconfig - Tips and Best Practices sections of the manual might be helpful
too.

-- The C compiler identification is GNU 12.1.0
-- The CXX compiler identification is GNU 12.1.0
-- The ASM compiler identification is GNU
-- Found assembler: /home/ian/zephyr-sdk-0.15.2/arm-zephyr-eabi/bin/arm-zephyr-eabi-gcc
-- Configuring done
-- Generating done
-- Build files have been written to: /home/ian/golioth-zephyr-workspace/modules/lib/golioth/build
-- west build: building application
[1/307] Preparing syscall dependency handling

[2/307] Generating include/generated/version.h
-- Zephyr version: 3.2.0 (/home/ian/golioth-zephyr-workspace/zephyr), build: zephyr-v3.2.0
[297/307] Linking C executable zephyr/zephyr_pre0.elf
FAILED: zephyr/zephyr_pre0.elf zephyr/zephyr_pre0.map 
: && ccache /home/ian/zephyr-sdk-0.15.2/arm-zephyr-eabi/bin/arm-zephyr-eabi-gcc  -gdwarf-4 zephyr/CMakeFiles/zephyr_pre0.dir/misc/empty_file.c.obj -o zephyr/zephyr_pre0.elf  -fuse-ld=bfd  -Wl,-T  zephyr/linker_zephyr_pre0.cmd  -Wl,-Map=/home/ian/golioth-zephyr-workspace/modules/lib/golioth/build/zephyr/zephyr_pre0.map  -Wl,--whole-archive  app/libapp.a  zephyr/libzephyr.a  zephyr/arch/common/libarch__common.a  zephyr/arch/arch/arm/core/aarch32/libarch__arm__core__aarch32.a  zephyr/arch/arch/arm/core/aarch32/cortex_m/libarch__arm__core__aarch32__cortex_m.a  zephyr/lib/libc/minimal/liblib__libc__minimal.a  zephyr/lib/posix/liblib__posix.a  zephyr/soc/arm/ti_lm3s6965/libsoc__arm__ti_lm3s6965.a  zephyr/subsys/net/libsubsys__net.a  zephyr/subsys/net/l2/ethernet/libsubsys__net__l2__ethernet.a  zephyr/subsys/net/ip/libsubsys__net__ip.a  zephyr/subsys/net/lib/dns/libsubsys__net__lib__dns.a  zephyr/drivers/console/libdrivers__console.a  zephyr/drivers/serial/libdrivers__serial.a  zephyr/drivers/net/libdrivers__net.a  zephyr/drivers/ethernet/libdrivers__ethernet.a  zephyr/drivers/timer/libdrivers__timer.a  modules/qcbor/lib..__modules__lib__qcbor__zephyr.a  modules/mbedtls/libmodules__mbedtls.a  -Wl,--no-whole-archive  zephyr/kernel/libkernel.a  zephyr/CMakeFiles/offsets.dir/./arch/arm/core/offsets/offsets.c.obj  -L"/home/ian/zephyr-sdk-0.15.2/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/12.1.0/thumb/v7-m/nofp"  -L/home/ian/golioth-zephyr-workspace/modules/lib/golioth/build/zephyr  -lgcc  zephyr/arch/common/libisr_tables.a  -no-pie  -mcpu=cortex-m3  -mthumb  -mabi=aapcs  -mfp16-format=ieee  -Wl,--gc-sections  -Wl,--build-id=none  -Wl,--sort-common=descending  -Wl,--sort-section=alignment  -Wl,-u,_OffsetAbsSyms  -Wl,-u,_ConfigAbsSyms  -nostdlib  -static  -Wl,-X  -Wl,-N  -Wl,--orphan-handling=warn && cd /home/ian/golioth-zephyr-workspace/modules/lib/golioth/build/zephyr && /usr/local/bin/cmake -E echo
/home/ian/zephyr-sdk-0.15.2/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/12.1.0/../../../../arm-zephyr-eabi/bin/ld.bfd: zephyr/libzephyr.a(coap.c.obj): in function `sys_rand_get':
/home/ian/golioth-zephyr-workspace/modules/lib/golioth/build/zephyr/include/generated/syscalls/rand32.h:57: undefined reference to `z_impl_sys_rand_get'
/home/ian/zephyr-sdk-0.15.2/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/12.1.0/../../../../arm-zephyr-eabi/bin/ld.bfd: zephyr/libzephyr.a(coap.c.obj): in function `sys_rand32_get':
/home/ian/golioth-zephyr-workspace/modules/lib/golioth/build/zephyr/include/generated/syscalls/rand32.h:32: undefined reference to `z_impl_sys_rand32_get'
/home/ian/zephyr-sdk-0.15.2/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/12.1.0/../../../../arm-zephyr-eabi/bin/ld.bfd: zephyr/libzephyr.a(sockets_tls.c.obj): in function `sys_rand_get':
/home/ian/golioth-zephyr-workspace/modules/lib/golioth/build/zephyr/include/generated/syscalls/rand32.h:57: undefined reference to `z_impl_sys_rand_get'
/home/ian/zephyr-sdk-0.15.2/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/12.1.0/../../../../arm-zephyr-eabi/bin/ld.bfd: zephyr/libzephyr.a(coap_req.c.obj): in function `sys_rand32_get':
/home/ian/golioth-zephyr-workspace/modules/lib/golioth/build/zephyr/include/generated/syscalls/rand32.h:32: undefined reference to `z_impl_sys_rand32_get'
/home/ian/zephyr-sdk-0.15.2/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/12.1.0/../../../../arm-zephyr-eabi/bin/ld.bfd: zephyr/subsys/net/ip/libsubsys__net__ip.a(net_context.c.obj): in function `sys_rand32_get':
/home/ian/golioth-zephyr-workspace/modules/lib/golioth/build/zephyr/include/generated/syscalls/rand32.h:32: undefined reference to `z_impl_sys_rand32_get'
/home/ian/zephyr-sdk-0.15.2/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/12.1.0/../../../../arm-zephyr-eabi/bin/ld.bfd: zephyr/subsys/net/ip/libsubsys__net__ip.a(net_shell.c.obj): in function `sys_rand32_get':
/home/ian/golioth-zephyr-workspace/modules/lib/golioth/build/zephyr/include/generated/syscalls/rand32.h:32: undefined reference to `z_impl_sys_rand32_get'
/home/ian/zephyr-sdk-0.15.2/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/12.1.0/../../../../arm-zephyr-eabi/bin/ld.bfd: zephyr/subsys/net/lib/dns/libsubsys__net__lib__dns.a(resolve.c.obj): in function `sys_rand32_get':
/home/ian/golioth-zephyr-workspace/modules/lib/golioth/build/zephyr/include/generated/syscalls/rand32.h:32: undefined reference to `z_impl_sys_rand32_get'
/home/ian/zephyr-sdk-0.15.2/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/12.1.0/../../../../arm-zephyr-eabi/bin/ld.bfd: zephyr/drivers/net/libdrivers__net.a(slip.c.obj): in function `sys_rand32_get':
/home/ian/golioth-zephyr-workspace/modules/lib/golioth/build/zephyr/include/generated/syscalls/rand32.h:32: undefined reference to `z_impl_sys_rand32_get'
collect2: error: ld returned 1 exit status
ninja: build stopped: subcommand failed.
FATAL ERROR: command exited with status 1: /usr/local/bin/cmake --build /home/ian/golioth-zephyr-workspace/modules/lib/golioth/build
```

## Passing Build

Working build after adding CONFIG
- CONFIG_ENTROPY_GENERATOR=y
- CONFIG_TEST_RANDOM_GENERATOR=y

```
(.venv) ➜  golioth git:(main) ✗ west build -b qemu_cortex_m3 samples/hello -p
-- west build: making build dir /home/ian/golioth-zephyr-workspace/modules/lib/golioth/build pristine
-- west build: generating a build system
Loading Zephyr default modules (Zephyr base).
-- Application: /home/ian/golioth-zephyr-workspace/modules/lib/golioth/samples/hello
-- Found Python3: /home/ian/golioth-zephyr-workspace/.venv/bin/python3 (found suitable exact version "3.8.10") found components: Interpreter 
-- Cache files will be written to: /home/ian/.cache/zephyr
-- Zephyr version: 3.2.0 (/home/ian/golioth-zephyr-workspace/zephyr)
-- Found west (found suitable version "0.14.0", minimum required is "0.7.1")
-- Board: qemu_cortex_m3
-- Found host-tools: zephyr 0.15.2 (/home/ian/zephyr-sdk-0.15.2)
-- Found toolchain: zephyr 0.15.2 (/home/ian/zephyr-sdk-0.15.2)
-- Found Dtc: /home/ian/zephyr-sdk-0.15.2/sysroots/x86_64-pokysdk-linux/usr/bin/dtc (found suitable version "1.6.0", minimum required is "1.4.6") 
-- Found BOARD.dts: /home/ian/golioth-zephyr-workspace/zephyr/boards/arm/qemu_cortex_m3/qemu_cortex_m3.dts
-- Generated zephyr.dts: /home/ian/golioth-zephyr-workspace/modules/lib/golioth/build/zephyr/zephyr.dts
-- Generated devicetree_generated.h: /home/ian/golioth-zephyr-workspace/modules/lib/golioth/build/zephyr/include/generated/devicetree_generated.h
-- Including generated dts.cmake file: /home/ian/golioth-zephyr-workspace/modules/lib/golioth/build/zephyr/dts.cmake
Parsing /home/ian/golioth-zephyr-workspace/modules/lib/golioth/samples/hello/Kconfig
Loaded configuration '/home/ian/golioth-zephyr-workspace/zephyr/boards/arm/qemu_cortex_m3/qemu_cortex_m3_defconfig'
Merged configuration '/home/ian/golioth-zephyr-workspace/modules/lib/golioth/samples/hello/prj.conf'
Configuration saved to '/home/ian/golioth-zephyr-workspace/modules/lib/golioth/build/zephyr/.config'
Kconfig header saved to '/home/ian/golioth-zephyr-workspace/modules/lib/golioth/build/zephyr/include/generated/autoconf.h'

warning: QEMU_ICOUNT_SHIFT (defined at boards/Kconfig:67) was assigned the value '6' but got the
value ''. Check these unsatisfied dependencies: QEMU_ICOUNT (=n). See
http://docs.zephyrproject.org/latest/kconfig.html#CONFIG_QEMU_ICOUNT_SHIFT and/or look up
QEMU_ICOUNT_SHIFT in the menuconfig/guiconfig interface. The Application Development Primer, Setting
Configuration Values, and Kconfig - Tips and Best Practices sections of the manual might be helpful
too.

-- The C compiler identification is GNU 12.1.0
-- The CXX compiler identification is GNU 12.1.0
-- The ASM compiler identification is GNU
-- Found assembler: /home/ian/zephyr-sdk-0.15.2/arm-zephyr-eabi/bin/arm-zephyr-eabi-gcc
CMake Warning at /home/ian/golioth-zephyr-workspace/zephyr/subsys/random/CMakeLists.txt:11 (message):
  

      Warning: CONFIG_TEST_RANDOM_GENERATOR is not a truly random generator.
      This capability is not secure and it is provided for testing purposes only.
      Use it carefully.


-- Configuring done
-- Generating done
-- Build files have been written to: /home/ian/golioth-zephyr-workspace/modules/lib/golioth/build
-- west build: building application
[1/309] Preparing syscall dependency handling

[2/309] Generating include/generated/version.h
-- Zephyr version: 3.2.0 (/home/ian/golioth-zephyr-workspace/zephyr), build: zephyr-v3.2.0
[299/309] Linking C executable zephyr/zephyr_pre0.elf

[303/309] Linking C executable zephyr/zephyr_pre1.elf

[309/309] Linking C executable zephyr/zephyr.elf
Memory region         Used Size  Region Size  %age Used
           FLASH:      194444 B       256 KB     74.17%
            SRAM:       51968 B        64 KB     79.30%
        IDT_LIST:          0 GB         2 KB      0.00%
```