### PR TITLE
simulating-devices: update qemu build command

### DIFF
--- a/docs/hardware/5-virtual-device/2-zephyr-quickstart/5-simulating-devices-qemu.md
+++ b/docs/hardware/5-virtual-device/2-zephyr-quickstart/5-simulating-devices-qemu.md
@@ -49,7 +49,7 @@ Save and exit (`ctrl+x` in nano)
 At this point, you can build a Golioth Zephyr project:
 
 ```
-west build -b qemu_cortex_m3 samples/hello -p
+west build -b qemu_x86 samples/hello -p
 ```
 
 and run it:


### PR DESCRIPTION
Update the build command to use the qemu_x68 target used in all of the Golioth samples.

This fixes the issues the @ilaue-prospr reported in #247. The Golioth Zephyr SDK targets qemu_x86 so the docs should target that as well.