### PR TITLE
Fix small typo in OTA uploading artifacts docs

### DIFF
--- a/docs/cloud/1-services/5-ota/2-uploading-artifacts.md
+++ b/docs/cloud/1-services/5-ota/2-uploading-artifacts.md
@@ -28,7 +28,7 @@ $ west build -b nrf52840dk_nrf52840 samples/dfu -p
 $ west sign -t imgtool --no-hex -B ./build/zephyr/app_update.bin -- --key ../../../bootloader/mcuboot/root-rsa-2048.pem --version 1.0.1
 ```
 
-Them you can upload to our backend using the following command:
+Then you can upload to our backend using the following command:
 
 ```
 # assuming you have a blueprint name nrf91


### PR DESCRIPTION
Fixes a small typo where "them" was used instead of "then".

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>