### PR TITLE
Update ESP-IDF Quickstart log tag line to match latest example

### DIFF
--- a/docs/hardware/2-esp32/1-espidf-quickstart/4-ota.md
+++ b/docs/hardware/2-esp32/1-espidf-quickstart/4-ota.md
@@ -24,7 +24,7 @@ updating the version number to `1.2.6`. For fun, also change the tag name to
 new firmware version is running.
 
 ```c title="changes to: golioth-firmware-sdk/examples/common/golioth_basics.c"
-#define TAG "golioth_basics_new"
+LOG_TAG_DEFINE(golioth_basics_new);
 
 // Current firmware version
 static const char* _current_version = "1.2.6";


### PR DESCRIPTION
While going through the [ESP-IDF Quickstart](https://docs.golioth.io/hardware/esp32/espidf-quickstart/), I noticed an inconsistency between the docs and the latest version of [golioth-firmware-sdk](https://github.com/golioth/golioth-firmware-sdk). Looks like these changes haven't been included in a release yet, but the quickstart instructions don't checkout to a specific version of the SDK so I continued by using the tip of `main`.

Looks like the logger tags set with `#define TAG "<tag name>"` were recently updated to use the macro `LOG_TAG_DEFINE(<tag name>` instead.

I did end up getting the ESP32 connected and I completed an OTA, very cool! :rocket: 
