### PR TITLE
Add reference for tagging apikeys

### DIFF
--- a/docs/reference/5-command-line-tools/1-goliothctl/goliothctl_apikeys_create.md
+++ b/docs/reference/5-command-line-tools/1-goliothctl/goliothctl_apikeys_create.md
@@ -39,7 +39,7 @@ id:"fe71a35c-0cb9-4643-9761-e95c332c2b1c"  key:"LQBgNB0LldJ4tyIDDzQd4tY7G060o8bV
 
 ```
   -h, --help                 help for create
-      --keyTag stringArray   key tag(s)
+      --keyTag stringArray   optionally assign one or more tags to the key being created
   -t, --type string          api key type [API_KEY JWT_KEY] (default "API_KEY")
 
 ```

--- a/docs/reference/5-command-line-tools/1-goliothctl/goliothctl_apikeys_create.md
+++ b/docs/reference/5-command-line-tools/1-goliothctl/goliothctl_apikeys_create.md
@@ -12,7 +12,6 @@ Create an API key or JSON Web Token (JWT) that can be used to connect to the Gol
 
 ### Synopsis
 
-The '--type' is API_KEY by default. To create a JWT use '--type JWT_KEY'. It's also possible to tag keys with one or more tag(s) using the '--keyTag'.
 
 ```
 goliothctl apikeys create [flags]

--- a/docs/reference/5-command-line-tools/1-goliothctl/goliothctl_apikeys_create.md
+++ b/docs/reference/5-command-line-tools/1-goliothctl/goliothctl_apikeys_create.md
@@ -10,7 +10,6 @@ hide_title: true
 
 Create an API key or JSON Web Token (JWT) that can be used to connect to the Golioth REST API.
 
-### Synopsis
 
 
 ```

--- a/docs/reference/5-command-line-tools/1-goliothctl/goliothctl_apikeys_create.md
+++ b/docs/reference/5-command-line-tools/1-goliothctl/goliothctl_apikeys_create.md
@@ -8,7 +8,7 @@ hide_title: true
 ---
 ## goliothctl apikeys create
 
-Create an API key or JWT that can be used to connect to the Golioth REST API.
+Create an API key or JSON Web Token (JWT) that can be used to connect to the Golioth REST API.
 
 ### Synopsis
 

--- a/docs/reference/5-command-line-tools/1-goliothctl/goliothctl_apikeys_create.md
+++ b/docs/reference/5-command-line-tools/1-goliothctl/goliothctl_apikeys_create.md
@@ -8,11 +8,11 @@ hide_title: true
 ---
 ## goliothctl apikeys create
 
-Create an API key.
+Create an API key or JWT that can be used to connect to the Golioth REST API.
 
 ### Synopsis
 
-Create an API key that can be used to connect to the Golioth REST API.
+The '--type' is API_KEY by default. To create a JWT use '--type JWT_KEY'. It's also possible to tag keys with one or more tag(s) using the '--keyTag'.
 
 ```
 goliothctl apikeys create [flags]
@@ -21,15 +21,27 @@ goliothctl apikeys create [flags]
 ### Examples
 
 ```
+# Create an API KEY
 > golioth apikeys create
 id:"5df88b8e-e208-41d4-b7e2-29192ab5de83"  key:"dLEtQLItz9eSHZYwuZGE5UlcgL2GOmHW" type:API_KEY
+
+# Create JWT
+> golioth apikeys create --type JWT_KEY
+id:"fe71a35c-0cb9-4643-9761-e95c332c2b1c"  key:"LQBgNB0LldJ4tyIDDzQd4tY7G060o8bV"  type:JWT_KEY  secret:"BpYxx835pZ1A8KUpfhWMNiGd1V0e0JB7"
+
+# Create Keys with tag(s)
+> golioth apikeys create --keyTag ktag-1
+> golioth apikeys create --keyTag ktag-1 --keyTag ktag-2
+> golioth apikeys create --type JWT_KEY --keyTag ktag-1 --keyTag ktag-2
 ```
 
 ### Options
 
 ```
-  -h, --help          help for create
-  -t, --type string   api key type [API_KEY JWT_KEY] (default "API_KEY")
+  -h, --help                 help for create
+      --keyTag stringArray   key tag(s)
+  -t, --type string          api key type [API_KEY JWT_KEY] (default "API_KEY")
+
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
PR related to the [GB-602: Add "name -> TAGs" field to API keys](https://golioth.atlassian.net/browse/GB-602).

Adding reference to tagging apikeys through the `goliothctl apikeys create` command.