### PR TITLE
fix: use lowercase for x-api-key

### DIFF
--- a/docs/reference/3-rest-api/2-auth.md
+++ b/docs/reference/3-rest-api/2-auth.md
@@ -35,7 +35,7 @@ id:"<api key uuid>"  key:"YOUR_JWT_KEY"  type:JWT_KEY  secret:"YOUR_JWT_SECRET"
 
 #### Using a Basic API Key
 
-Basic API Key, doesn't require any extra processing to be used and a `X-API-Key` header can be used. Now let's list devices on a project using `curl`:
+Basic API Key, doesn't require any extra processing to be used and a `x-api-key` header can be used. Now let's list devices on a project using `curl`:
 
 ```
 $ curl -H "x-api-key: YOUR_API_KEY" https://api.golioth.io/v1/projects/{project-id}/devices

--- a/docs/reference/4-websocket/2-auth.md
+++ b/docs/reference/4-websocket/2-auth.md
@@ -35,7 +35,7 @@ id:"<api key uuid>"  key:"YOUR_JWT_KEY"  type:JWT_KEY  secret:"YOUR_JWT_SECRET"
 
 #### Using a Basic API Key to authenticate WebSocket connection
 
-Basic API Key doesn't require any extra processing to be used and a `X-API-Key` query parameter must be used as you can see:
+Basic API Key doesn't require any extra processing to be used and a `x-api-key` query parameter must be used as you can see:
 ```
 ?x-api-key={API_KEY}
 ```


### PR DESCRIPTION
Using `X-API-Key` in a query will cause authentication to fail. This should be all lowercase: `x-api-key`