### PR TITLE
add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+max_line_length = 80
+trim_trailing_whitespace = true


### PR DESCRIPTION
Use editorconfig file to set standard line endings, widths, character set, whitespace trimming, and file endings.