### PR TITLE
hardware overview: add 'Start Here' section

### DIFF
--- a/docs/getting-started/2-console/5-choose-device.md
+++ b/docs/getting-started/2-console/5-choose-device.md
@@ -4,8 +4,6 @@ title: Choose which device to run on
 pagination_next: null
 ---
 
-import ChooseDevice from '/docs/partials-common/getting-started_choose-device.md'  
+import ChooseDevice from '/docs/partials-common/getting-started_choose-device.md'
 
 <ChooseDevice/>
-
-Alternatively, visit the [Hardware Overview](../../hardware/1-home.md) section to learn about other  supported devices.

--- a/docs/hardware/1-home.md
+++ b/docs/hardware/1-home.md
@@ -47,7 +47,7 @@ A continuously verified board:
 * is tested on every release of the [Golioth Zephyr SDK](https://github.com/golioth/golioth-zephyr-sdk).
 * is regularly tested and used by the Golioth development team.
 * has first class support and maintenance from Golioth. If you encounter a problem
-    with one of these boards, you can reach out to us on [Discord](https://golioth.io/discord) or
+    with one of these boards, you can reach out to us on [the Golioth Forum](https://forum.golioth.io) or
     [file a bug report](https://github.com/golioth/golioth-zephyr-sdk/issues),
     and we will address it quickly.
 
@@ -64,7 +64,7 @@ A verified board:
     was tested on an older version of the Golioth Zephyr SDK, but may not
     have been tested on the most recent commits.
 * is supported and maintained by the Golioth development team. You can reach
-    out to us on [Discord](https://golioth.io/discord) for help and troubleshooting.
+    out to us on [the Golioth Forum](https://forum.golioth.io) for help and troubleshooting.
 
 Boards in this category cover a wider range of MCUs and peripherals.
 
@@ -82,5 +82,5 @@ If it's in the list, there's a good chance it will work with Golioth with
 low development effort.
 
 If you're interested in using a board from this category, you can reach out to us on
-[Discord](https://golioth.io/discord), and we can help you with next steps to
+[the Golioth Forum](https://forum.golioth.io), and we can help you with next steps to
 get the board connected to Golioth.

--- a/docs/hardware/1-home.md
+++ b/docs/hardware/1-home.md
@@ -9,6 +9,31 @@ The Hardware section includes a catalog of supported boards for the Golioth
 platform. Additionally, there are quickstart guides and recommended boards for
 common MCUs, such as the ESP32 and nRF91.
 
+## Start Here
+
+Golioth offers two device SDKs that support a wide range of hardware. Here is
+some guidance on what to use when setting up a development environment for your
+hardware.
+
+| Vendor     | SDK                  | Quickstart | Note |
+| ---------- | -------------------- | ---------- | ---- |
+| Espressif  | [Golioth Firmware SDK](https://github.com/golioth/golioth-firmware-sdk) | [ESP32 ESP-IDF Quickstart](/hardware/esp32/espidf-quickstart/set-up-espidf) | Use for ESP32 MCUs |
+| Espressif  | [Golioth Zephyr SDK](https://github.com/golioth/golioth-zephyr-sdk)   | [ESP32 Zephyr Quickstart](/hardware/esp32/zephyr-quickstart/set-up-zephyr) | Use for ESP32 MCUs |
+| Infineon   | [Golioth Firmware SDK](https://github.com/golioth/golioth-firmware-sdk) | ModusToolbox&trade; [Readme](https://github.com/golioth/golioth-firmware-sdk/tree/main/examples/modus_toolbox) / [Webinar](https://blog.golioth.io/a-recap-of-how-to-collect-data-from-iot-sensors-using-golioth-and-the-infineon-modustoolbox/) | Use for Infineon MCUs like PSoC6 |
+| Nordic     | [Golioth Zephyr SDK](https://github.com/golioth/golioth-zephyr-sdk)   | [nRF9160 Zephyr Quickstart](/hardware/nrf91/zephyr-quickstart/set-up-zephyr) | Use for Nordic MCUs like nRF9160 and nRF7002 |
+| NXP        | [Golioth Zephyr SDK](https://github.com/golioth/golioth-zephyr-sdk)   | [mimxrt1060evkb Zephyr Quickstart](/hardware/mimxrt1060_evkb/zephyr-quickstart/set-up-zephyr) | Use for NXP MCUs like i.MX RT1062 and i.MX RT1024 |
+| Other Vendors | [Golioth Zephyr SDK](https://github.com/golioth/golioth-zephyr-sdk) | [mimxrt1060evkb Zephyr Quickstart](/hardware/mimxrt1060_evkb/zephyr-quickstart/set-up-zephyr) | Many other MCUs are supported by Zephyr will work with Golioth! Follow this quickstart and substitute your board name in the build examples. |
+
+:::info Don't see your hardware listed?
+
+The Golioth Firmware SDK includes a [porting
+guide](https://github.com/golioth/golioth-firmware-sdk/blob/main/docs/Porting_Guide.md)
+that you can follow to add a port for your platform. If you are interested in
+Golioth adding new platform support, please [contact
+us](mailto:hello@golioth.io).
+
+:::
+
 ## Board Support Tiers
 
 Golioth has three levels of board support: Continuously Verified, Verified,

--- a/docs/partials-common/getting-started_choose-device.md
+++ b/docs/partials-common/getting-started_choose-device.md
@@ -1,5 +1,4 @@
-The next step is to connect a device to Golioth using Zephyr. Choose from our 3 quickstart guides that are continuations of the Platform Guide you just completed.
+The next step is to connect a device to Golioth using either the Golioth
+Firmware SDK or the Golioth Zephyr SDK.
 
-* [ESP32](/hardware/esp32)
-* [nRF91](/hardware/nrf91)
-* [Virtual device](/hardware/virtual-devices)
+## Next: [Hardware Overview](/hardware)


### PR DESCRIPTION
add a matrix of hardware vendors that outlines Golioth SDK support and links to quickstart guides.