### PR TITLE
firmware: certs: update hint text for device name

### DIFF
--- a/docs/firmware/golioth-firmware-sdk/authentication/certificate-auth.md
+++ b/docs/firmware/golioth-firmware-sdk/authentication/certificate-auth.md
@@ -65,7 +65,7 @@ converted to the `DER` binary format for use with the Golioth Zephyr SDK.
 
 ```shell
 PROJECT_SLUG='your-golioth-projectID'
-DEVICE_NAME='choose-hardware-id-for-this-device'
+DEVICE_NAME='choose-a-unique-name-for-this-device'
 SERVER_NAME='golioth'
 CLIENT_NAME="${PROJECT_SLUG}-${DEVICE_NAME}"
 


### PR DESCRIPTION
The hint text in the device cert generation script incorrectly referenced a unique hardware id. This updates the text to reference a unique device name.