### PR TITLE
update Zephyr SDK install instructions

### DIFF
--- a/docs/partials-common/install-zephyr-sdk-toolchain.md
+++ b/docs/partials-common/install-zephyr-sdk-toolchain.md
@@ -15,14 +15,14 @@ values={[
 
 ```console
 cd ~
-wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.15.2/zephyr-sdk-0.15.2_linux-x86_64.tar.gz
+wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.3/zephyr-sdk-0.16.3_linux-x86_64.tar.xz
 ```
 
-Unpack the archive and run the installer. The SDK will be placed in the `~/zephyr-sdk-0.15.2` directory:
+Unpack the archive and run the installer. The SDK will be placed in the `~/zephyr-sdk-0.16.3` directory:
 
 ```console
-tar -xvf zephyr-sdk-0.15.2_linux-x86_64.tar.gz
-cd zephyr-sdk-0.15.2
+tar -xvf zephyr-sdk-0.16.3_linux-x86_64.tar.xz
+cd zephyr-sdk-0.16.3
 ./setup.sh
 ```
 
@@ -31,7 +31,7 @@ Answer `y` to both of the questions asked during the setup process.
 Install udev rules, which allow you to flash most Zephyr boards as a regular user:
 
 ```console
-sudo cp ~/zephyr-sdk-0.15.2/sysroots/x86_64-pokysdk-linux/usr/share/openocd/contrib/60-openocd.rules /etc/udev/rules.d
+sudo cp ~/zephyr-sdk-0.16.3/sysroots/x86_64-pokysdk-linux/usr/share/openocd/contrib/60-openocd.rules /etc/udev/rules.d
 sudo udevadm control --reload
 ```
 
@@ -40,14 +40,14 @@ sudo udevadm control --reload
 
 ```console
 cd ~
-wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.15.2/zephyr-sdk-0.15.2_macos-x86_64.tar.gz
+wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.3/zephyr-sdk-0.16.3_macos-x86_64.tar.xz
 ```
 
 Unpack the archive and run the installer. The SDK will be placed in the `~/zephyr-sdk-0.15.2` directory:
 
 ```console
-tar -xvf zephyr-sdk-0.15.2_macos-x86_64.tar.gz
-cd zephyr-sdk-0.15.2
+tar xvf zephyr-sdk-0.16.3_macos-x86_64.tar.xz
+cd zephyr-sdk-0.16.3
 ./setup.sh
 ```
 
@@ -58,9 +58,9 @@ Unpack the archive and run the installer. The SDK will be placed in the `%HOMEPA
 
 ```console
 cd %HOMEPATH%
-wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.15.2/zephyr-sdk-0.15.2_windows-x86_64.zip
-unzip zephyr-sdk-0.15.2_windows-x86_64.zip
-cd zephyr-sdk-0.15.2
+wget https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v0.16.3/zephyr-sdk-0.16.3_windows-x86_64.7z
+7z x zephyr-sdk-0.16.3_windows-x86_64.7z
+cd zephyr-sdk-0.16.3
 setup.cmd
 ```
 


### PR DESCRIPTION
Use most recent version of the Zephyr SDK toolchain.