### PR TITLE
Add sign up hyperlink to Getting Started

### DIFF
--- a/docs/getting-started/1-overview.md
+++ b/docs/getting-started/1-overview.md
@@ -4,9 +4,9 @@ title: Platform Overview
 slug: /getting-started
 ---
 
-This guide will prepare your Golioth account to communicate directly with your hardware devices. 
+This guide will prepare your Golioth account to communicate directly with your hardware devices.
 
-* Register for your account on Golioth
+* [Register for your account on Golioth](https://console.golioth.io/login/)
 * Add a project and provision your first device
 
 Once completed, you can to move on to [the Hardware section](../hardware/1-home.md) to get a device (or emulated device) communicating with the Golioth Cloud.


### PR DESCRIPTION
Add Sign Up hyperlink to the Getting Started section as [suggested by a user in the forum](https://forum.golioth.io/t/small-improvement-for-getting-started/374).