### PR TITLE
add tiers redirect to production

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -16,7 +16,7 @@
           "type": 301
         },
         {
-          "source": "/cloud/tiers",
+          "source": "/cloud/tiers{,/**}",
           "destination": "https://golioth.io/pricing",
           "type": 301
         }
@@ -41,6 +41,11 @@
         {
           "source": "/hardware/:arch/quickstart{,/**}",
           "destination": "/hardware/:arch/zephyr-quickstart",
+          "type": 301
+        },
+        {
+          "source": "/cloud/tiers{,/**}",
+          "destination": "https://golioth.io/pricing",
           "type": 301
         }
       ],


### PR DESCRIPTION
When the previous commit was merged it included a redirect for dev but not for prod. This commit adds the prod redirect, and ensures that URLs with and without a trailing slash will both be redirected correctly.