### PR TITLE
getting-started: zephyr: fix repository URL

### DIFF
--- a/docs/_partials-common/ncs-install-golioth-firmware-sdk-for-unix.md
+++ b/docs/_partials-common/ncs-install-golioth-firmware-sdk-for-unix.md
@@ -3,7 +3,7 @@ import TabItem from '@theme/TabItem';
 
 ```
 cd ~
-west init -m https://github.com/golioth/golioth-zephyr-sdk.git --mr v0.9.0 --mf west-ncs.yml ~/golioth-ncs-workspace
+west init -m https://github.com/golioth/golioth-firmware-sdk.git --mr v0.9.0 --mf west-ncs.yml ~/golioth-ncs-workspace
 cd golioth-ncs-workspace
 west update
 ```

--- a/docs/_partials-common/ncs-install-golioth-firmware-sdk-for-windows.md
+++ b/docs/_partials-common/ncs-install-golioth-firmware-sdk-for-windows.md
@@ -3,7 +3,7 @@ import TabItem from '@theme/TabItem';
 
 ```
 cd %HOMEPATH%
-west init -m https://github.com/golioth/golioth-zephyr-sdk.git --mr v0.9.0 --mf west-ncs.yml %HOMEPATH%/golioth-ncs-workspace
+west init -m https://github.com/golioth/golioth-firmware-sdk.git --mr v0.9.0 --mf west-ncs.yml %HOMEPATH%/golioth-ncs-workspace
 cd golioth-ncs-workspace
 west update
 ```

--- a/docs/_partials-common/zephyr-install-golioth-firmware-sdk-for-unix.md
+++ b/docs/_partials-common/zephyr-install-golioth-firmware-sdk-for-unix.md
@@ -9,7 +9,7 @@ Depending on your internet and I/O speed, `west update` can take upwards of 5 or
 
 ```
 cd ~
-west init -m https://github.com/golioth/golioth-zephyr-sdk.git --mr v0.9.0 --mf west-zephyr.yml ~/golioth-zephyr-workspace
+west init -m https://github.com/golioth/golioth-firmware-sdk.git --mr v0.9.0 --mf west-zephyr.yml ~/golioth-zephyr-workspace
 cd golioth-zephyr-workspace
 west update
 ```


### PR DESCRIPTION
Update installation commands to use the Golioth Firwmare SDK.

The Zephyr/NCS quickstarts used `west init` repository paths for the Golioth Zephyr SDK when they should have been using the Zephyr support in the Golioth Firmware SDK

Resolves #338 
