### PR TITLE
add Golioth Zephyr SDK deprecation notice to point to Golioth Firmware SDK

### DIFF
--- a/docs/_partials-common/deprecation-warning-zephyr-sdk.md
+++ b/docs/_partials-common/deprecation-warning-zephyr-sdk.md
@@ -1,0 +1,7 @@
+:::caution Use the Golioth Firmware SDK for all Zephyr projects
+
+The Golioth Zephyr SDK is deprecated. Please use the [Golioth Firmware
+SDK](/firmware/golioth-firmware-sdk/). ([Migration
+Guide](https://github.com/golioth/golioth-firmware-sdk/blob/main/docs/Migration_Guide_Zephyr.md))
+
+:::

--- a/docs/firmware/zephyr-device-sdk/README.md
+++ b/docs/firmware/zephyr-device-sdk/README.md
@@ -7,8 +7,10 @@ title: Golioth Zephyr SDK
 This section documents the deprecated "Golioth Zephyr SDK". All support for
 Zephyr RTOS has been moved to the [Golioth Firmware
 SDK](https://github.com/golioth/golioth-firmware-sdk). Please use that for all
-new projects and follow the Migration Guide to update existing projects. There
-will be no further support or updates to this repository after July 31, 2024.
+new projects and follow [the Migration
+Guide](https://github.com/golioth/golioth-firmware-sdk/blob/main/docs/Migration_Guide_Zephyr.md)
+to update existing projects. There will be no further support or updates to this
+repository after July 31, 2024.
 
 - Documentation for the [Golioth Firmware SDK](/firmware/golioth-firmware-sdk/)
   (includes Zephyr support)

--- a/docs/firmware/zephyr-device-sdk/authentication/README.md
+++ b/docs/firmware/zephyr-device-sdk/authentication/README.md
@@ -3,6 +3,10 @@ title: Device Authentication
 sidebar_position: 1
 ---
 
+import Deprecated from '/docs/_partials-common/deprecation-warning-zephyr-sdk.md'
+
+<Deprecated/>
+
 TLS & DTLS are the basis for our device authentication service as well as how
 the device authenticates a Golioth instance. The diagram below illustrates how
 the device's credentials (either an X.509 Certificate or a Pre-Shared Key pair)

--- a/docs/firmware/zephyr-device-sdk/authentication/certificate-auth.md
+++ b/docs/firmware/zephyr-device-sdk/authentication/certificate-auth.md
@@ -5,6 +5,10 @@ sidebar_position: 1
 
 # Certificate Authentication with Golioth
 
+import Deprecated from '/docs/_partials-common/deprecation-warning-zephyr-sdk.md'
+
+<Deprecated/>
+
 Golioth uses the X.509 standard with the Elliptic Curve Digital Signature
 Algorithm (ECDSA) for certificate authentication. This delivers much more
 robust security compared to Pre-Shared Key (PSK) authentication.
@@ -41,7 +45,7 @@ For testing we will use `openssl` to generate a self-signed root certificate.
 ```shell
 SERVER_NAME='golioth'
 
-# Generate an elliptic curve private key 
+# Generate an elliptic curve private key
 # Run `openssl ecparam -list_curves` to list all available algorithms
 # Keep this key safe! Anyone who has it can sign authentic-looking device certificates
 openssl ecparam -name prime256v1 -genkey -noout -out "${SERVER_NAME}.key.pem"

--- a/docs/firmware/zephyr-device-sdk/authentication/psk-auth.md
+++ b/docs/firmware/zephyr-device-sdk/authentication/psk-auth.md
@@ -3,6 +3,10 @@ title: PSK Authentication
 sidebar_position: 1
 ---
 
+import Deprecated from '/docs/_partials-common/deprecation-warning-zephyr-sdk.md'
+
+<Deprecated/>
+
 If you have already worked through the [Getting Started
 Guide](/getting-started), you are familiar with creating device credentials
 using the Golioth Console (or the `goliothctl` command line tool). Credentials

--- a/docs/firmware/zephyr-device-sdk/device-settings-service.md
+++ b/docs/firmware/zephyr-device-sdk/device-settings-service.md
@@ -3,6 +3,10 @@ title: Device Settings Service
 sidebar_position: 1.7
 ---
 
+import Deprecated from '/docs/_partials-common/deprecation-warning-zephyr-sdk.md'
+
+<Deprecated/>
+
 The Golioth Device Settings Service enables you to update settings for all
 devices in your fleet at the same time. The service can also target device
 groups by hardware blueprint, and individual devices. This is ideal for common

--- a/docs/firmware/zephyr-device-sdk/firmware-upgrade/2-build-sample-application.md
+++ b/docs/firmware/zephyr-device-sdk/firmware-upgrade/2-build-sample-application.md
@@ -3,6 +3,10 @@ title: Over-the-Air (OTA) Update Walkthrough
 sidebar_position: 2
 ---
 
+import Deprecated from '/docs/_partials-common/deprecation-warning-zephyr-sdk.md'
+
+<Deprecated/>
+
 Over-the-Air (OTA) updates are a type of Device Firmware Upgrade (DFU); for this
 sample let's consider the two terms synonymous. In this page we'll walk through
 the DFU sample found in [the Golioth Zephyr (and NCS)

--- a/docs/firmware/zephyr-device-sdk/firmware-upgrade/4-watch-device-update.md
+++ b/docs/firmware/zephyr-device-sdk/firmware-upgrade/4-watch-device-update.md
@@ -3,6 +3,10 @@ title: Monitor A Device Update
 sidebar_position: 2
 ---
 
+import Deprecated from '/docs/_partials-common/deprecation-warning-zephyr-sdk.md'
+
+<Deprecated/>
+
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 

--- a/docs/firmware/zephyr-device-sdk/firmware-upgrade/5-dfu-sample-guide.md
+++ b/docs/firmware/zephyr-device-sdk/firmware-upgrade/5-dfu-sample-guide.md
@@ -2,6 +2,10 @@
 title: DFU Sample Code Review
 ---
 
+import Deprecated from '/docs/_partials-common/deprecation-warning-zephyr-sdk.md'
+
+<Deprecated/>
+
 Golioth has [a Device Firmware Update (DFU) sample
 application](https://github.com/golioth/golioth-zephyr-sdk/tree/main/samples/dfu)
 that demonstrates how to connect with Golioth for an Over-the-Air (OTA) update.

--- a/docs/firmware/zephyr-device-sdk/firmware-upgrade/README.md
+++ b/docs/firmware/zephyr-device-sdk/firmware-upgrade/README.md
@@ -4,6 +4,10 @@ sidebar_position: 1
 slug: /firmware/device-sdk/firmware-upgrade
 ---
 
+import Deprecated from '/docs/_partials-common/deprecation-warning-zephyr-sdk.md'
+
+<Deprecated/>
+
 This section will guide you through Over-The-Air (OTA) firmware updates for
 embedded devices using the Golioth Device Firmware Update (DFU) service. The
 Golioth Zephyr SDK includes DFU sample code which runs on all Continuously

--- a/docs/firmware/zephyr-device-sdk/golioth-client.md
+++ b/docs/firmware/zephyr-device-sdk/golioth-client.md
@@ -3,6 +3,10 @@ title: Golioth Client
 sidebar_position: 1.5
 ---
 
+import Deprecated from '/docs/_partials-common/deprecation-warning-zephyr-sdk.md'
+
+<Deprecated/>
+
 The Golioth Client runs in its own thread and handles all communications with
 the Golioth Cloud. Your program must instantiate and start a Golioth Client,
 registering callbacks as needed.

--- a/docs/firmware/zephyr-device-sdk/light-db-stream/README.md
+++ b/docs/firmware/zephyr-device-sdk/light-db-stream/README.md
@@ -3,6 +3,10 @@ title: LightDB Stream Client Overview
 sidebar_position: 1
 ---
 
+import Deprecated from '/docs/_partials-common/deprecation-warning-zephyr-sdk.md'
+
+<Deprecated/>
+
 LightDB Stream is a persistent database service hosted by Golioth. The LightDB
 Stream service can be used to create time series data that can be extracted
 using utilities described in the [Command Line

--- a/docs/firmware/zephyr-device-sdk/light-db-stream/guide-lightdb-stream.md
+++ b/docs/firmware/zephyr-device-sdk/light-db-stream/guide-lightdb-stream.md
@@ -3,6 +3,10 @@ title: LightDB Stream Request
 sidebar_position: 2
 ---
 
+import Deprecated from '/docs/_partials-common/deprecation-warning-zephyr-sdk.md'
+
+<Deprecated/>
+
 The LightDB Stream sample contains many of the same elements as the other LightDB samples. The primary difference between LightDB State and LightDB Stream is the persistence of data. LightDB State is useful for applications of state management. With LightDB Stream, timestamped datapoints can be uploaded using the LightDB Stream service to accumulate time-series databases. Check out the [Cloud](/device-management) section of the documentation for information regarding accessing the accumulated data.
 
 ## Includes

--- a/docs/firmware/zephyr-device-sdk/light-db/README.md
+++ b/docs/firmware/zephyr-device-sdk/light-db/README.md
@@ -3,6 +3,10 @@ title: LightDB State Client Overview
 sidebar_position: 1
 ---
 
+import Deprecated from '/docs/_partials-common/deprecation-warning-zephyr-sdk.md'
+
+<Deprecated/>
+
 LightDB is a state-based database service hosted by Golioth. It can be used to
 create applications involving resource state. Device state such as LED on/off,
 door lock position, or thermostat settings are easy to manage using the Golioth

--- a/docs/firmware/zephyr-device-sdk/light-db/guide-light-db-observe.md
+++ b/docs/firmware/zephyr-device-sdk/light-db/guide-light-db-observe.md
@@ -3,6 +3,10 @@ title: LightDB Observe Request
 sidebar_position: 3
 ---
 
+import Deprecated from '/docs/_partials-common/deprecation-warning-zephyr-sdk.md'
+
+<Deprecated/>
+
 The [LightDB Observe sample
 application](https://github.com/golioth/golioth-zephyr-sdk/tree/main/samples/lightdb/observe)
 demonstrates how to use the Golioth Zephyr SDK to register a LightDB State

--- a/docs/firmware/zephyr-device-sdk/light-db/guide-lightdb-get.md
+++ b/docs/firmware/zephyr-device-sdk/light-db/guide-lightdb-get.md
@@ -3,6 +3,10 @@ title: LightDB Get Request
 sidebar_position: 2
 ---
 
+import Deprecated from '/docs/_partials-common/deprecation-warning-zephyr-sdk.md'
+
+<Deprecated/>
+
 The [LightDB Get sample
 application](https://github.com/golioth/golioth-zephyr-sdk/tree/main/samples/lightdb/get)
 demonstrates how to retrieve resources from LightDB State using the Golioth

--- a/docs/firmware/zephyr-device-sdk/light-db/guide-lightdb-set.md
+++ b/docs/firmware/zephyr-device-sdk/light-db/guide-lightdb-set.md
@@ -3,6 +3,10 @@ title: LightDB Set Request
 sidebar_position: 4
 ---
 
+import Deprecated from '/docs/_partials-common/deprecation-warning-zephyr-sdk.md'
+
+<Deprecated/>
+
 The [LightDB Set sample
 application](https://github.com/golioth/golioth-zephyr-sdk/tree/main/samples/lightdb/set)
 demonstrates how to send resources to LightDB State using the Golioth SDK. Data

--- a/docs/firmware/zephyr-device-sdk/logging/README.md
+++ b/docs/firmware/zephyr-device-sdk/logging/README.md
@@ -3,6 +3,10 @@ title: Logging Client Overview
 sidebar_position: 1
 ---
 
+import Deprecated from '/docs/_partials-common/deprecation-warning-zephyr-sdk.md'
+
+<Deprecated/>
+
 The Logging sample demonstrates how logging can be executed using the Zephyr logging subsystem.  The messages generated can be forwarded to Golioth server using project configuration.
 
 ![Console](../assets/logging-svg-a4.svg)

--- a/docs/firmware/zephyr-device-sdk/logging/guide-logging.md
+++ b/docs/firmware/zephyr-device-sdk/logging/guide-logging.md
@@ -3,6 +3,10 @@ title: Logging Sample
 sidebar_position: 2
 ---
 
+import Deprecated from '/docs/_partials-common/deprecation-warning-zephyr-sdk.md'
+
+<Deprecated/>
+
 The Logging example demonstrates the integration of the Golioth SDK with the Zephyr logging subsystem.  With the proper configuration, log statements can be printed to serial as well as passed along to Golioth's logging service.
 
 The sample contains elements common to most Golioth samples.  These are the Wi-Fi configuration verification and connection, and the ```golioth_system_client_start()```. These are described in more detail in the [LightDB Get Request](https://docs.golioth.io/firmware/device-sdk/light-db/guide-lightdb-get/) document.  After that there is a while loop that contains examples of various log level logging methods as well as demonstrating calling functions with logging methods contained therein.  The two keys to understanding this sample are the [Zephyr logging subsystem](https://docs.zephyrproject.org/latest/reference/logging/index.html) and the configurations found in the project which enable the logging subsystem messages to be duplicated to Golioth Cloud.

--- a/docs/firmware/zephyr-device-sdk/migration_guide.md
+++ b/docs/firmware/zephyr-device-sdk/migration_guide.md
@@ -1,0 +1,10 @@
+---
+title: Migration Guide
+sidebar_position: 0.5
+---
+
+To help in migrating your application from the Golioth Zephyr SDK to the Golioth
+Firmware SDK, please see the Migration Guide:
+
+* [Migrating your code from the Golioth Zephyr SDK to the Golioth Firmware
+  SDK](https://github.com/golioth/golioth-firmware-sdk/blob/main/docs/Migration_Guide_Zephyr.md)

--- a/docs/firmware/zephyr-device-sdk/remote-procedure-call.md
+++ b/docs/firmware/zephyr-device-sdk/remote-procedure-call.md
@@ -3,6 +3,10 @@ title: Remote Procedure Call (RPC)
 sidebar_position: 7
 ---
 
+import Deprecated from '/docs/_partials-common/deprecation-warning-zephyr-sdk.md'
+
+<Deprecated/>
+
 The Golioth Remote Procedure Call (RPC) allows a server-side command to execute
 a function on the remote device, including supplying input parameters and
 receiving output data from the function. RPC is handy for things like executing

--- a/docs/firmware/zephyr-device-sdk/zephyr-app.md
+++ b/docs/firmware/zephyr-device-sdk/zephyr-app.md
@@ -4,6 +4,10 @@ hide_title: false
 sidebar_position: 99
 ---
 
+import Deprecated from '/docs/_partials-common/deprecation-warning-zephyr-sdk.md'
+
+<Deprecated/>
+
 While the [Quickstart](/getting-started) focuses on running a sample that's located within the Zephyr file-hierarchy,
 it's simple enough to create a new application that's separate from Zephyr.
 


### PR DESCRIPTION
* [Migration Guide: add link and sidebar entry](https://github.com/golioth/docs/commit/4484d7358d22452db21ea77ad7858c256dcb9868)
* [add deprecation to all Golioth Zephyr SDK pages](https://github.com/golioth/docs/commit/3cf876c3ad7985ed0f61bc7659d897c493e1ff8e)