### PR TITLE
getting started: fix directory change

### DIFF
--- a/docs/_partials-common/ncs-install-golioth-firmware-sdk-for-unix.md
+++ b/docs/_partials-common/ncs-install-golioth-firmware-sdk-for-unix.md
@@ -8,7 +8,7 @@ import FirmwareSdkVer from '!!raw-loader!/docs/_versions/golioth-firmware-sdk.md
     <CodeBlock language="console">
         { `cd ~` + "\n" }
         { `west init -m https://github.com/golioth/golioth-firmware-sdk.git --mr ${FirmwareSdkVer.replace(/(\n)/gm, "")} --mf west-ncs.yml ~/golioth-ncs-workspace` + "\n" }
-        { `cd golioth-ncs-workspace` + "\n" }
+        { `cd golioth-ncs-workspace/modules/lib/golioth-firmware-sdk` + "\n" }
         { `git submodule update --init --recursive` + "\n" }
         { `west update` }
     </CodeBlock>

--- a/docs/_partials-common/ncs-install-golioth-firmware-sdk-for-windows.md
+++ b/docs/_partials-common/ncs-install-golioth-firmware-sdk-for-windows.md
@@ -8,7 +8,7 @@ import FirmwareSdkVer from '!!raw-loader!/docs/_versions/golioth-firmware-sdk.md
     <CodeBlock language="console">
         {` cd %HOMEPATH%` + "\n" }
         {` west init -m https://github.com/golioth/golioth-firmware-sdk.git --mr ${FirmwareSdkVer.replace(/(\n)/gm, "")} --mf west-ncs.yml %HOMEPATH%/golioth-ncs-workspace` + "\n" }
-        {` cd golioth-ncs-workspace` + "\n" }
+        {` cd golioth-ncs-workspace/modules/lib/golioth-firmware-sdk` + "\n" }
         { `git submodule update --init --recursive` + "\n" }
         {` west update` }
     </CodeBlock>

--- a/docs/_partials-common/zephyr-install-golioth-firmware-sdk-for-unix.md
+++ b/docs/_partials-common/zephyr-install-golioth-firmware-sdk-for-unix.md
@@ -8,7 +8,7 @@ import FirmwareSdkVer from '!!raw-loader!/docs/_versions/golioth-firmware-sdk.md
     <CodeBlock language="console">
         { `cd ~` + "\n" }
         { `west init -m https://github.com/golioth/golioth-firmware-sdk.git --mr ${FirmwareSdkVer.replace(/(\n)/gm, "")} --mf west-zephyr.yml ~/golioth-zephyr-workspace` + "\n" }
-        { `cd golioth-zephyr-workspace` + "\n" }
+        { `cd golioth-zephyr-workspace/modules/lib/golioth-firmware-sdk` + "\n" }
         { `git submodule update --init --recursive` + "\n" }
         { `west update` }
     </CodeBlock>

--- a/docs/_partials-common/zephyr-install-golioth-firmware-sdk-for-windows.md
+++ b/docs/_partials-common/zephyr-install-golioth-firmware-sdk-for-windows.md
@@ -8,7 +8,7 @@ import FirmwareSdkVer from '!!raw-loader!/docs/_versions/golioth-firmware-sdk.md
     <CodeBlock language="console">
         { `cd c:\\` + "\n" }
         { `west init -m https://github.com/golioth/golioth-firmware-sdk.git --mr ${FirmwareSdkVer.replace(/(\n)/gm, "")} --mf west-zephyr.yml golioth-zephyr-workspace` + "\n" }
-        { `cd golioth-zephyr-workspace` + "\n" }
+        { `cd golioth-zephyr-workspace/modules/lib/golioth-firmware-sdk` + "\n" }
         { `git submodule update --init --recursive` + "\n" }
         { `west update` }
     </CodeBlock>


### PR DESCRIPTION
When installing a Golioth workspace for Zephyr/NCS you must change into the SDK directory before running submodule init.