### PR TITLE
Add links to firmware SDK docs from device auth reference

### DIFF
--- a/docs/reference/2-protocols/2-device-auth.md
+++ b/docs/reference/2-protocols/2-device-auth.md
@@ -34,14 +34,19 @@ See the getting started guide:
 
 * Golioth Console: [authorize PSK
   devices](/getting-started/console/manage-devices).
-* Command line Tools: [authorize PSK devices](/reference/command-line-tools/tutorial/authorize-devices).
+* Command Line Tools: [authorize PSK devices](/reference/command-line-tools/tutorial/authorize-devices).
 
+To use a PSK on your device, see the [Firmware SDK
+documentation](/firmware/golioth-firmware-sdk/authentication/psk-auth).
 
 ## Client Certificate Authentication
 
 Certificate authentication is more complex to setup and use than PSK authentication, but it provides a superior level of security. It also enables you to perform zero-touch provisioning of devices.
 
 The trusted root or intermediate certificates are first configured on your Golioth project. When a device connects to Golioth using a certificate signed by one of your trusted certificates, the device will be *automatically provisioned* in that project.
+
+To use certificates on your device, see the [Firmware SDK
+documentation](/firmware/golioth-firmware-sdk/authentication/certificate-auth).
 
 ### Server authentication
 


### PR DESCRIPTION
Adds links to the firmware SDK documentation that details how to use PSKs and Certificates with the SDK on devices.