### PR TITLE
Fix broken link to logging service

### DIFF
--- a/docs/firmware/zephyr-device-sdk/logging/README.md
+++ b/docs/firmware/zephyr-device-sdk/logging/README.md
@@ -11,4 +11,4 @@ The Logging sample demonstrates how logging can be executed using the Zephyr log
 
 ![Console](../assets/logging-svg-a4.svg)
 
-Checkout the [Logging guide](https://docs.golioth.io/device-management/services/logging/) for a walkthrough of the sample demonstrating the firmware calls used to interact with the Golioth Logging service.
+Checkout the [Logging guide](/device-management/logging) for a walkthrough of the sample demonstrating the firmware calls used to interact with the Golioth Logging service.


### PR DESCRIPTION
Fixes a broken link to logging service in Zephyr SDK documentation.