### PR TITLE
Remove reference to unsupported LightDB Stream device GET endpoint

### DIFF
--- a/docs/reference/2-protocols/1-coap/4-lightdb-stream.md
+++ b/docs/reference/2-protocols/1-coap/4-lightdb-stream.md
@@ -14,7 +14,6 @@ How to use guides:
 | Method | Description     | Path              | Content Format |
 | ------ | --------------- | ----------------- | -------------- |
 | POST   | Send data       | `/.s/{path=\*\*}` | JSON/CBOR      |
-| GET    | Get latest data | `/.s/{path=\*\*}` | JSON/CBOR      |
 
 > `path` can be any valid URI sub path. Ex:
 >
@@ -22,7 +21,7 @@ How to use guides:
 >
 > /.s/location
 
-To demonstrate the operations here, let's imagine that we are tracking an asset using an IoT device. The location data from our device is going to periodically pushed to a LightDB Stream.
+To demonstrate the operations here, let's imagine that we are tracking an asset using an IoT device. The location data from our device is going to be periodically pushed to LightDB Stream.
 
 ### Parameters and attributes that are known:
 
@@ -37,7 +36,7 @@ The body can be a JSON/CBOR object or a single value in the following formats:
 - `integer`
 - `string`
 
-You can also send a batch request by sending an array at the root level and with different timestamps:
+You can also send a batch request by sending an array at the root level with different timestamps:
 
 ```
 $ coap --path /.s/position -m POST --psk-id deadbeef-id@my-project-id --psk supersecret --host coap.golioth.io -b "[{\"ts\": 1626362266059, \"latitude\": 37.75, \"longitude\" : -122.57, \"speed\": 5 }, {\"ts\": 1626362276059, \"latitude\": 38.75, \"longitude\" : -123.57, \"speed\": 10 }]" --format json


### PR DESCRIPTION
Removes the reference to the GET endpoint to LightDB Stream, which is no longer supported.