### PR TITLE
reference: coap: ota: correctly reference reason codes

### DIFF
--- a/docs/reference/2-protocols/1-coap/7-ota.md
+++ b/docs/reference/2-protocols/1-coap/7-ota.md
@@ -97,6 +97,6 @@ currently downloading an update of the `main` package; going from the current
 
 ### Firmware Report Reason
 
-- For a full list of `state` codes, please see the
+- For a full list of `reason` codes, please see the
   [golioth_ota_reason](https://firmware-sdk-docs.golioth.io/group__golioth__ota.html)
   enum on the Golioth Firmware SDK doxygen reference.


### PR DESCRIPTION
The reason code section previously referenced state codes by mistake.