### PR TITLE
Update mongo and influx outputstream docs to correctly reflect format

### DIFF
--- a/docs/data-routing/2-output-streams/1-mongo/README.md
+++ b/docs/data-routing/2-output-streams/1-mongo/README.md
@@ -157,8 +157,7 @@ Data,
       "seconds": 1682614592,
       "nanos": 987338334
     },
-    "project_id": "64230895aff1018f3aacabab",
-    "integration_id": "644aa93df9021bf366e0a255",
+    "project_id": "my-first-project",
     "data": {
       "hello": "world"
     }
@@ -171,8 +170,7 @@ We transform the above CloudEvent to the following BSON document:
 {
     timestamp: 2023-08-15T21:27:06.219+00:00,
     metadata: {
-        device_id: "62def0a5316b32515f36fe2e",
-        project_id: "64230895aff1018f3aacabab",
+        project_id: "my-first-project",
     },
     _id: ObjectId('64dbedaa2ee9615b83f21576'),
     data: {

--- a/docs/data-routing/2-output-streams/8-influx/README.md
+++ b/docs/data-routing/2-output-streams/8-influx/README.md
@@ -99,8 +99,7 @@ Data,
       "seconds": 1682614592,
       "nanos": 987338334
     },
-    "project_id": "64230895aff1018f3aacabab",
-    "integration_id": "644aa93df9021bf366e0a255",
+    "project_id": "my-first-project",
     "data": {
       "hello": "world"
     }
@@ -110,5 +109,5 @@ Data,
 We transform the above CloudEvent to the following line protocol:
 
 ```
-GoliothEvent,{"project_id"="64230895aff1018f3aacabab","integration_id"="644aa93df9021bf366e0a255"} "hello=world" 1682614592
+GoliothEvent,{"project_id"="my-first-project"} "hello=world" 1682614592
 ```


### PR DESCRIPTION
Updates the mongo and influx outputstream docs examples to correctly reflect the format of data sent to each destination.