### PR TITLE
landing page: update title

### DIFF
--- a/docs/landing_page.md
+++ b/docs/landing_page.md
@@ -1,6 +1,6 @@
 ---
 id: home
-title: What is Golioth?
+title: Golioth Docs
 slug: /
 hide_title: true
 ---


### PR DESCRIPTION
Title currently says "What is Golioth?" which is awkward when shown on a browser tab. This change update to "Golioth Docs".

![image](https://github.com/golioth/docs/assets/367685/a9f9d500-8aaf-4dc3-b47d-aa13c8de7b77)

resolves https://github.com/golioth/devrel-issue-tracker/issues/390
