### PR TITLE
Update redirects and change priority order

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -71,38 +71,28 @@
           "type": 301
         },
         {
-          "source": "/cloud/output-streams/:streams*",
-          "destination": "/data-routing/output-streams/:streams",
-          "type": 301
-        },
-        {
           "source": "/cloud/output-streams{,/**}",
-          "destination": "/data-routing/output-streams/",
-          "type": 301
-        },
-        {
-          "source": "/cloud/services{,/**}",
-          "destination": "/data-routing/application-services/",
+          "destination": "/data-routing/",
           "type": 301
         },
         {
           "source": "/cloud/services/lightdb/:state*",
-          "destination": "/data-routing/application-services/lightdb-state/:state",
+          "destination": "/application-services/lightdb-state/:state",
           "type": 301
         },
         {
           "source": "/services/lightdb{,/**}",
-          "destination": "/data-routing/application-services/lightdb-state/",
+          "destination": "/application-services/lightdb-state/",
           "type": 301
         },
         {
           "source": "/cloud/services/lightdb-stream/:stream*",
-          "destination": "/data-routing/application-services/lightdb-stream/:stream",
+          "destination": "/application-services/lightdb-stream/:stream",
           "type": 301
         },
         {
           "source": "/cloud/services/lightdb-stream{,/**}",
-          "destination": "/data-routing/application-services/lightdb-stream/",
+          "destination": "/application-services/lightdb-stream/",
           "type": 301
         },
         {
@@ -133,6 +123,11 @@
         {
           "source": "/cloud/services/settings{,/**}",
           "destination": "/device-management/settings",
+          "type": 301
+        },
+        {
+          "source": "/cloud/services{,/**}",
+          "destination": "/application-services/",
           "type": 301
         },
         {
@@ -285,37 +280,32 @@
         },
         {
           "source": "/cloud/output-streams/:streams*",
-          "destination": "/data-routing/output-streams/:streams",
+          "destination": "/data-routing/",
           "type": 301
         },
         {
           "source": "/cloud/output-streams{,/**}",
-          "destination": "/data-routing/output-streams/",
-          "type": 301
-        },
-        {
-          "source": "/cloud/services{,/**}",
-          "destination": "/data-routing/application-services/",
+          "destination": "/data-routing/",
           "type": 301
         },
         {
           "source": "/cloud/services/lightdb/:state*",
-          "destination": "/data-routing/application-services/lightdb-state/:state",
+          "destination": "/application-services/lightdb-state/:state",
           "type": 301
         },
         {
           "source": "/services/lightdb{,/**}",
-          "destination": "/data-routing/application-services/lightdb-state/",
+          "destination": "/application-services/lightdb-state/",
           "type": 301
         },
         {
           "source": "/cloud/services/lightdb-stream/:stream*",
-          "destination": "/data-routing/application-services/lightdb-stream/:stream",
+          "destination": "/application-services/lightdb-stream/:stream",
           "type": 301
         },
         {
           "source": "/cloud/services/lightdb-stream{,/**}",
-          "destination": "/data-routing/application-services/lightdb-stream/",
+          "destination": "/application-services/lightdb-stream/",
           "type": 301
         },
         {
@@ -346,6 +336,11 @@
         {
           "source": "/cloud/services/settings{,/**}",
           "destination": "/device-management/settings",
+          "type": 301
+        },
+        {
+          "source": "/cloud/services{,/**}",
+          "destination": "/application-services/",
           "type": 301
         },
         {


### PR DESCRIPTION
Updates redirects for new data routing structure and changes priority order such that more specific rules come before less specific ones.

From [Firebase docs](https://firebase.google.com/docs/hosting/full-config#redirects):

> Important: Within the redirects attribute, Hosting applies the redirect defined by the first rule with a URL pattern that matches the requested path. So, you need to deliberately order the rules within the redirects attribute.