### PR TITLE
getting started: use full URL in manage devices page

### DIFF
--- a/docs/getting-started/2-console/3-manage-devices.md
+++ b/docs/getting-started/2-console/3-manage-devices.md
@@ -59,8 +59,10 @@ demonstrated as a happy path to get a demo device running right away. However,
 Golioth supports and recommends using X509 certificate (ECDSA) for your
 production devices.
 
+<!-- Use full URL here because this page gets imported to the Developer Training
+repo and we want the URL to work over there too -->
 * Firmware Section: [Certificate
-  Authentication](/firmware/golioth-firmware-sdk/authentication/certificate-auth)
+  Authentication](https://docs.golioth.io/firmware/golioth-firmware-sdk/authentication/certificate-auth)
 :::
 
 Congratulations, you're ready to move on to selecting hardware!


### PR DESCRIPTION
Two pages of the getting started guide are imported in the Developer Training to walk people through the console registration process. When linking to other pages, use the full URL (https://docs.golioth.io/etc) to ensure pages don't have broken links when imported outside of this repo.