### PR TITLE
Add memfault data destination documentation and example

### DIFF
--- a/docs/data-routing/4-destinations/9-memfault.md
+++ b/docs/data-routing/4-destinations/9-memfault.md
@@ -1,0 +1,65 @@
+---
+title: memfault
+---
+
+|   |   |
+|---|:---:|
+|__Latest Version__| `v1.0.0` |
+|__Input Content Type__| `application/octet-stream` |
+
+The `memfault` destination uploads [chunk
+data](https://docs.memfault.com/docs/mcu/data-from-firmware-to-the-cloud/) to
+[Memfault](https://memfault.com/).
+
+:::info
+The Golioth device ID will be used as its serial number on Memfault.
+:::
+
+### Parameters
+
+|Parameter|Type|Description|Required|
+|---|---|---|:---:|
+|`project_key`|`string`| The Memfault [project key](https://docs.memfault.com/docs/platform/data-routes/) for chunk uploads. |✅|
+
+### Example Secrets
+
+`MEMFAULT_PROJECT_KEY`
+```
+FOQnIsDwjLasMuOfTRhtwLLPLEuJC2aM
+```
+
+### Example Usage
+
+```yaml
+    destination:
+      type: memfault
+      version: v1
+      parameters:
+        project_key: $MEMFAULT_PROJECT_KEY
+```
+
+### Example Input
+
+> Binary data displayed as hex encoded for documentation purposes only.
+
+```
+00000000: a702 0103 0107 6944 3132 3334 3536 3738  ......iD12345678
+00000010: 0a65 6e72 6635 3209 6531 2e30 2e33 0663  .enrf52.e1.0.3.c
+00000020: 6576 7404 a101 8d1a 0036 ee80 0019 4e20  evt......6....N
+00000030: 1a00 0927 c018 c803 190b b800 0a04 0038  ...'...........8
+00000040: 3519 03e8
+```
+
+### Example Output
+
+Input data is sent to Memfault unmodified.
+
+> Binary data displayed as hex encoded for documentation purposes only.
+
+```
+00000000: a702 0103 0107 6944 3132 3334 3536 3738  ......iD12345678
+00000010: 0a65 6e72 6635 3209 6531 2e30 2e33 0663  .enrf52.e1.0.3.c
+00000020: 6576 7404 a101 8d1a 0036 ee80 0019 4e20  evt......6....N
+00000030: 1a00 0927 c018 c803 190b b800 0a04 0038  ...'...........8
+00000040: 3519 03e8
+```

--- a/docs/data-routing/5-examples/15-memfault.md
+++ b/docs/data-routing/5-examples/15-memfault.md
@@ -1,0 +1,24 @@
+---
+title: Memfault
+---
+import Pipeline from '@site/src/components/usethispipeline'
+
+[Memfault](https://memfault.com/) is an embedded device observability platform
+that automatically collects coredumps, logs, and metric data. Pipelines can be
+used to deliver [chunk
+data](https://docs.memfault.com/docs/mcu/data-from-firmware-to-the-cloud/)
+supplied by the Memfault [firmware
+SDK](https://github.com/memfault/memfault-firmware-sdk) to the Memfault platform
+using a device's existing connection to Golioth.
+
+The following example demonstrates forwarding chunk data sent to the `/mflt`
+path to Memfault. No transformers are necessary as the binary data is uploaded
+unmodified.
+
+:::info Reminder
+Make sure to create a [secret](/data-routing/secrets) named
+`MEMFAULT_PROJECT_KEY` with a valid [Memfault project
+key](https://docs.memfault.com/docs/platform/data-routes/).
+:::
+
+<Pipeline link='https://console.golioth.io/pipeline?name=Memfault&pipeline=ZmlsdGVyOgogIHBhdGg6ICIvbWZsdCIKICBjb250ZW50X3R5cGU6IGFwcGxpY2F0aW9uL29jdGV0LXN0cmVhbQpzdGVwczoKICAtIG5hbWU6IHN0ZXAwCiAgICBkZXN0aW5hdGlvbjoKICAgICAgdHlwZTogbWVtZmF1bHQKICAgICAgdmVyc2lvbjogdjEKICAgICAgcGFyYW1ldGVyczoKICAgICAgICBwcm9qZWN0X2tleTogJE1FTUZBVUxUX1BST0pFQ1RfS0VZ' />


### PR DESCRIPTION
Adds documentation for the memfault data destination.

Signed-off-by: Daniel Mangum <georgedanielmangum@gmail.com>

Adds an example pipeline for the memfault data destination.

Signed-off-by: Daniel Mangum <georgedanielmangum@gmail.com>