### PR TITLE
Update for zephyr 3.7

### DIFF
--- a/docs/firmware/golioth-firmware-sdk/firmware-upgrade/fw-update-zephyr.md
+++ b/docs/firmware/golioth-firmware-sdk/firmware-upgrade/fw-update-zephyr.md
@@ -51,7 +51,7 @@ Console](https://console.golioth.io).
 ### 2. Initial build and flash
 
 ```console
-west build -b nrf9160dk_nrf9160_ns examples/zephyr/fw_update
+west build -b nrf9160dk/nrf9160/ns examples/zephyr/fw_update
 west flash
 ```
 

--- a/docs/getting-started/3-device-examples/2-compile-example-code/1-zephyr/02-zephyr-samples.md
+++ b/docs/getting-started/3-device-examples/2-compile-example-code/1-zephyr/02-zephyr-samples.md
@@ -180,7 +180,7 @@ values={[
 <TabItem value="nrf52840">
 
 ```console
-west build -b nrf52840dk_nrf52840 examples/zephyr/hello
+west build -b nrf52840dk/nrf52840 examples/zephyr/hello
 west flash
 ```
 </TabItem>
@@ -196,7 +196,7 @@ west flash
 <TabItem value="esp32">
 
 ```console
-west build -b esp32_devkitc_wrover examples/zephyr/hello
+west build -b esp32_devkitc_wrover/esp32/procpu examples/zephyr/hello
 west flash
 ```
 </TabItem>
@@ -215,7 +215,7 @@ programmer](https://docs.rakwireless.com/Product-Categories/WisTrio/RAK5010/Quic
 :::
 
 ```console
-west build -b rak5010_nrf52840 examples/zephyr/hello
+west build -b rak5010 examples/zephyr/hello
 west flash -r jlink
 ```
 </TabItem>

--- a/docs/getting-started/3-device-examples/2-compile-example-code/1-zephyr/02-zephyr-samples.md
+++ b/docs/getting-started/3-device-examples/2-compile-example-code/1-zephyr/02-zephyr-samples.md
@@ -28,6 +28,8 @@ for a range of development boards as part of our continuous integration (CI).
   Kit](https://www.nxp.com/design/design-center/development-boards/i-mx-evaluation-and-development-boards/i-mx-rt1024-evaluation-kit:MIMXRT1024-EVK)
 * [ESP32 DevKitC
   WROVER](https://www.espressif.com/en/products/devkits/esp32-devkitc)
+* [RAK5010 WisTrio NB-IoT Tracker Pro (Quectel
+  BG95-M3)](https://docs.rakwireless.com/Product-Categories/WisTrio/RAK5010)
 
 This page includes build commands for these boards. You may model configuration
 for your own target hardware on the configuration and overlay files found in the
@@ -91,6 +93,7 @@ values={[
 {label: 'Nordic nRF52840', value: 'nrf52840'},
 {label: 'NXP RT1024', value: 'rt1024'},
 {label: 'ESP32', value: 'esp32'},
+{label: 'RAK5010', value: 'rak5010'},
 ]}>
 
 <TabItem value="nrf52840">
@@ -122,6 +125,14 @@ CONFIG_GOLIOTH_SAMPLE_PSK="my-psk"
 # Your WiFi credentials
 CONFIG_GOLIOTH_SAMPLE_WIFI_SSID="my-wifi"
 CONFIG_GOLIOTH_SAMPLE_WIFI_PSK="my-psk"
+```
+</TabItem>
+
+<TabItem value="rak5010">
+
+```config title="examples/zephyr/hello/prj.conf"
+CONFIG_GOLIOTH_SAMPLE_PSK_ID="my-psk-id"
+CONFIG_GOLIOTH_SAMPLE_PSK="my-psk"
 ```
 </TabItem>
 </Tabs>
@@ -163,6 +174,7 @@ values={[
 {label: 'Nordic nRF52840', value: 'nrf52840'},
 {label: 'NXP RT1024', value: 'rt1024'},
 {label: 'ESP32', value: 'esp32'},
+{label: 'RAK5010', value: 'rak5010'},
 ]}>
 
 <TabItem value="nrf52840">
@@ -186,6 +198,25 @@ west flash
 ```console
 west build -b esp32_devkitc_wrover examples/zephyr/hello
 west flash
+```
+</TabItem>
+
+<TabItem value="rak5010">
+
+:::tip RAK5010 Requires an External Programmer
+
+You will need an external programmer to flash the RAK5010. There are many
+options, including J-Link, BlackMagic Probe, and using the offboard debug header
+on an nRF9160dk.
+
+For this example [we've connected a J-Link
+programmer](https://docs.rakwireless.com/Product-Categories/WisTrio/RAK5010/Quickstart/#through-j-link-rtt-viewer).
+
+:::
+
+```console
+west build -b rak5010_nrf52840 examples/zephyr/hello
+west flash -r jlink
 ```
 </TabItem>
 </Tabs>

--- a/docs/getting-started/3-device-examples/2-compile-example-code/2-zephyr-ncs/02-zephyr-samples.md
+++ b/docs/getting-started/3-device-examples/2-compile-example-code/2-zephyr-ncs/02-zephyr-samples.md
@@ -110,7 +110,7 @@ authentication and store credentials outside of the firmware binary itself.
 ### Build the firmware and flashing the device
 
 ```console
-west build -b nrf9160dk_nrf9160_ns examples/zephyr/hello
+west build -b nrf9160dk/nrf9160/ns examples/zephyr/hello
 west flash
 ```
 


### PR DESCRIPTION
Change board names to use forward slash instead of underscore to match new device model for Zephyr v3.7.0.

This should not be merged until Golioth Firmware SDK v0.15.0 is released.

resolves https://github.com/golioth/firmware-issue-tracker/issues/618