### PR TITLE
reference: remove deprecated SDK and replace category page

### DIFF
--- a/docs/reference/1-home.md
+++ b/docs/reference/1-home.md
@@ -12,7 +12,5 @@ and advanced platform features.
 - Command Line Tools
   - [goliothctl](/reference/command-line-tools/goliothctl/goliothctl/)
   - [coap](/reference/command-line-tools/coap/coap/)
-- Device SDKs
-  - [Golioth Firmware SDK Reference](/reference/device-sdks/golioth-firmware-sdk)
-  - [Golioth Zephyr SDK Reference](/reference/device-sdks/golioth-zephyr-sdk)
+- Device SDK: [Golioth Firmware SDK Reference](/reference/golioth-firmware-sdk)
 - [Billing](/reference/billing)

--- a/docs/reference/5-device-sdks/2-zephyr-sdk.md
+++ b/docs/reference/5-device-sdks/2-zephyr-sdk.md
@@ -1,8 +1,0 @@
----
-id: golioth-zephyr-sdk
-title: Golioth Zephyr SDK
----
-
-The documentation for the [Golioth Zephyr SDK](https://github.com/golioth/golioth-zephyr-sdk/) is automatically generated using Doxygen and can be view at our external reference site:
-
-* [Golioth Zephyr SDK Doxygen Reference](https://zephyr-sdk-docs.golioth.io/)

--- a/docs/reference/5-device-sdks/_category_.yml
+++ b/docs/reference/5-device-sdks/_category_.yml
@@ -1,4 +1,0 @@
-label: 'Device SDKs'
-position: 6 # float position is supported
-collapsible: true # make the category collapsible
-collapsed: true # keep the category open by default

--- a/docs/reference/5-golioth-firmware-sdk.md
+++ b/docs/reference/5-golioth-firmware-sdk.md
@@ -1,5 +1,4 @@
 ---
-id: golioth-firmware-sdk
 title: Golioth Firmware SDK
 ---
 

--- a/firebase.json
+++ b/firebase.json
@@ -432,6 +432,11 @@
           "source": "/firmware/zephyr-device-sdk{,/**}",
           "destination": "/firmware/golioth-firmware-sdk",
           "type": 301
+        },
+        {
+          "source": "/reference/device-sdks{,/**}",
+          "destination": "/reference/golioth-firmware-sdk",
+          "type": 301
         }
       ],
       "rewrites": [


### PR DESCRIPTION
This PR places the Golioth Firmware SDK reference page as a top-level entry in the References section. We continue to host this placeholder page that points to the external doxygen as future plans will incorporate the doxygen into the main docs site.

- Remove references to the deprecated Golioth Zephyr SDK.
- Replace "Device SDKs" category the Golioth Firmware SDK page.