### PR TITLE
data-routing: transformers: struct-to-json: fix example yaml

### DIFF
--- a/docs/data-routing/3-transformers/6-struct-to-json.md
+++ b/docs/data-routing/3-transformers/6-struct-to-json.md
@@ -55,7 +55,7 @@ the string member in the payload.
             type: u8
           - name: string2
             type: string
-            length: string2_len
+            lengthField: string2_len
 ```
 
 ### Example Input


### PR DESCRIPTION
The example YAML used `length` where it should have used `lengthField`