### PR TITLE
docs: firmware: use --sysbuild for nrf9160dk fw_update builds

### DIFF
--- a/docs/_partials-common/build-fw-nrf91.md
+++ b/docs/_partials-common/build-fw-nrf91.md
@@ -13,7 +13,7 @@ values={[
 
 ```console
 cd ~/golioth-ncs-workspace/zephyr
-west build -p auto -b  nrf9160dk_nrf9160_ns samples/basic/minimal
+west build -p auto -b  nrf9160dk/nrf9160/ns samples/basic/minimal
 ```
 
 </TabItem>
@@ -21,7 +21,7 @@ west build -p auto -b  nrf9160dk_nrf9160_ns samples/basic/minimal
 
 ```console
 cd ~/golioth-ncs-workspace/zephyr
-west build -p auto -b  nrf9160dk_nrf9160_ns samples/basic/minimal
+west build -p auto -b  nrf9160dk/nrf9160/ns samples/basic/minimal
 ```
 
 </TabItem>
@@ -29,7 +29,7 @@ west build -p auto -b  nrf9160dk_nrf9160_ns samples/basic/minimal
 
 ```console
 cd %HOMEPATH%\golioth-ncs-workspace\zephyr
-west build -p auto -b  nrf9160dk_nrf9160_ns samples\basic\minimal
+west build -p auto -b  nrf9160dk/nrf9160/ns samples\basic\minimal
 ```
 
 </TabItem>

--- a/docs/firmware/golioth-firmware-sdk/firmware-upgrade/fw-update-zephyr.md
+++ b/docs/firmware/golioth-firmware-sdk/firmware-upgrade/fw-update-zephyr.md
@@ -83,7 +83,7 @@ CONFIG_MCUBOOT_IMGTOOL_SIGN_VERSION="1.2.4"
 Then build the application a second time.
 
 ```console
-west build -b nrf9160dk_nrf9160_ns examples/zephyr/fw_update
+west build -b nrf9160dk/nrf9160/ns examples/zephyr/fw_update
 ```
 
 :::note

--- a/docs/firmware/golioth-firmware-sdk/firmware-upgrade/fw-update-zephyr.md
+++ b/docs/firmware/golioth-firmware-sdk/firmware-upgrade/fw-update-zephyr.md
@@ -51,24 +51,12 @@ Console](https://console.golioth.io).
 ### 2. Initial build and flash
 
 ```console
-west build -b nrf9160dk/nrf9160/ns examples/zephyr/fw_update
+west build -b nrf9160dk/nrf9160/ns --sysbuild examples/zephyr/fw_update
 west flash
 ```
 
 By default this will build and run version `v1.2.3` firmware on the Nordic
 nRF9160 development kit.
-
-:::tip Building for other devices
-
-The Nordic version of Zephyr (NCS) uses a slightly different build command from
-upstream Zephyr. For non-Nordic boards the build command should also use the
-`--sysbuild` flag:
-
-```console
-# Example build command for NXP i.MX RT1024 Evaluation Kit
-west build -b mimxrt1024_evk --sysbuild examples/zephyr/fw_update
-west flash
-```
 
 :::
 
@@ -83,7 +71,7 @@ CONFIG_MCUBOOT_IMGTOOL_SIGN_VERSION="1.2.4"
 Then build the application a second time.
 
 ```console
-west build -b nrf9160dk/nrf9160/ns examples/zephyr/fw_update
+west build -b nrf9160dk/nrf9160/ns --sysbuild examples/zephyr/fw_update
 ```
 
 :::note


### PR DESCRIPTION
Using sysbuild is now recommended with new NCS versions, as the old multi-image
build system got deprecated. The resulting application upgrade
file (app_update.bin) is still the same as in old NCS.