### PR TITLE
firmware: golioth_client_config is struct, not typdef

### DIFF
--- a/docs/firmware/golioth-firmware-sdk/authentication/certificate-auth.md
+++ b/docs/firmware/golioth-firmware-sdk/authentication/certificate-auth.md
@@ -129,7 +129,7 @@ int main(void) {
     size_t tls_client_crt_len = sizeof_your_crt_der_byte_array;
     size_t tls_client_key_len = sizeof_your_key_der_byte_array;
 
-    golioth_client_config_t client_config = {
+    struct golioth_client_config client_config = {
         .credentials = {
             .auth_type = GOLIOTH_TLS_AUTH_TYPE_PKI,
             .pki = {

--- a/docs/firmware/golioth-firmware-sdk/authentication/psk-auth.md
+++ b/docs/firmware/golioth-firmware-sdk/authentication/psk-auth.md
@@ -15,7 +15,7 @@ uint8_t* client_psk = pointer_to_your_psk_array;
 size_t client_psk_id_len = strlen_of_your_psk_id_array;
 size_t client_psk_len = strlen_of_your_psk_array;
 
-golioth_client_config_t client_config = {
+struct golioth_client_config client_config = {
         .credentials = {
                 .auth_type = GOLIOTH_TLS_AUTH_TYPE_PSK,
                 .psk = {

--- a/docs/firmware/golioth-firmware-sdk/golioth-client.md
+++ b/docs/firmware/golioth-firmware-sdk/golioth-client.md
@@ -26,7 +26,7 @@ authentication:
 const char* golioth_psk_id = "device@project";
 const char* golioth_psk = "supersecret";
 
-golioth_client_config_t client_config = {
+struct golioth_client_config client_config = {
     .credentials = {
         .auth_type = GOLIOTH_TLS_AUTH_TYPE_PSK,
         .psk = {
@@ -47,7 +47,7 @@ parameter.
 
 ```c
 int main(void) {
-    client = golioth_client_create(client_config);
+    client = golioth_client_create(&client_config);
 ```
 
 ## Registering a Callback Function


### PR DESCRIPTION
Update to use `struct golioth_client_config` to match changes to SDK made in https://github.com/golioth/golioth-firmware-sdk/commit/c3a1c06715e13aa6d6c62409a03c0d7ca922a9df