### PR TITLE
reference: update goliothctl for current state of APIKEY

### DIFF
--- a/docs/reference/4-command-line-tools/1-goliothctl/goliothctl_apikeys_create.md
+++ b/docs/reference/4-command-line-tools/1-goliothctl/goliothctl_apikeys_create.md
@@ -8,7 +8,7 @@ hide_title: true
 ---
 ## goliothctl apikeys create
 
-Create an API key or JSON Web Token (JWT) that can be used to connect to the Golioth REST API.
+Create an API key that can be used to connect to the Golioth REST API.
 
 
 
@@ -23,14 +23,9 @@ goliothctl apikeys create [flags]
 > golioth apikeys create
 id:"5df88b8e-e208-41d4-b7e2-29192ab5de83"  key:"dLEtQLItz9eSHZYwuZGE5UlcgL2GOmHW" type:API_KEY
 
-# Create JWT
-> golioth apikeys create --type JWT_KEY
-id:"fe71a35c-0cb9-4643-9761-e95c332c2b1c"  key:"LQBgNB0LldJ4tyIDDzQd4tY7G060o8bV"  type:JWT_KEY  secret:"BpYxx835pZ1A8KUpfhWMNiGd1V0e0JB7"
-
 # Create Keys with tag(s)
 > golioth apikeys create --keyTag ktag-1
 > golioth apikeys create --keyTag ktag-1 --keyTag ktag-2
-> golioth apikeys create --type JWT_KEY --keyTag ktag-1 --keyTag ktag-2
 ```
 
 ### Options
@@ -38,7 +33,7 @@ id:"fe71a35c-0cb9-4643-9761-e95c332c2b1c"  key:"LQBgNB0LldJ4tyIDDzQd4tY7G060o8bV
 ```
   -h, --help                 help for create
       --keyTag stringArray   optionally assign one or more tags to the key being created
-  -t, --type string          api key type [API_KEY JWT_KEY] (default "API_KEY")
+  -t, --type string          api key type (default "API_KEY")
 
 ```
 


### PR DESCRIPTION
Update the `goliothctl` reference page to show only the basic APIKEY type type that is currently supported by Golioth.