### PR TITLE
[location] location service docs path updates

### DIFF
--- a/docs/application-services/3-location/2-resolving.md
+++ b/docs/application-services/3-location/2-resolving.md
@@ -1,5 +1,4 @@
 ---
-id: resolving
 title: Resolving Location
 ---
 

--- a/docs/application-services/3-location/3-querying.md
+++ b/docs/application-services/3-location/3-querying.md
@@ -1,5 +1,4 @@
 ---
-id: querying
 title: Querying Location
 ---
 
@@ -16,8 +15,8 @@ historical device location and provides a map view of fleets in the
 
 ### Fleet Location Visualization
 
-Projects using the Golioth Location service can the location of devices that
-have recently obtained position information by navigating to the `Location`
+Projects using the Golioth Location service can observe the location of devices
+that have recently obtained position information by navigating to the `Location`
 section in the console.
 
 ### Device Location Queries

--- a/docs/application-services/3-location/README.md
+++ b/docs/application-services/3-location/README.md
@@ -27,7 +27,7 @@ capabilities, or opting to use it sparingly, may be optimal. In these cases,
 devices can leverage network-based positioning, which is still able to provide
 location data with accuracy on the order of tens to hundreds of meters.
 
-#### Indoor Devices, and Devices in Urban Locations
+#### Indoor Devices and Devices in Urban Locations
 
 Some environments make leveraging GNSS challenging or impossible. Devices that
 are typically indoors or in dense urban areas will frequently struggle to

--- a/docs/reference/2-device-api/3-api-docs/8-location.md
+++ b/docs/reference/2-device-api/3-api-docs/8-location.md
@@ -1,5 +1,4 @@
 ---
-id: location
 title: Location
 ---
 


### PR DESCRIPTION
Fixes the path structure for location service docs to use file names rather than id.