### PR TITLE
Specify directory for virtual devices workspace; Fix ToC for zephyr install pages

### DIFF
--- a/docs/firmware/hardware/5-virtual-devices/2-zephyr-quickstart/5-simulating-devices-qemu.md
+++ b/docs/firmware/hardware/5-virtual-devices/2-zephyr-quickstart/5-simulating-devices-qemu.md
@@ -1,27 +1,28 @@
 ---
 id: simulating-devices-qemu
 title: Simulating devices with QEMU
+toc_max_heading_level: 2
 ---
 
-### Install West
+## Install Dependencies and West
 
 import SetupZephyr from '/docs/_partials-common/zephyr-setup-dependencies.md'
 
 <SetupZephyr workspace_directory="golioth-zephyr-workspace"/>
 
-### Install Golioth Firmware SDK
+## Install Golioth Firmware SDK
 
 import InstallZephyrSDK from '/docs/_partials-common/zephyr-install-golioth-firmware-sdk.md'
 
 <InstallZephyrSDK/>
 
-### Toolchain check
+## Toolchain check
 
 import CheckToolchain from './\_partials/check-toolchain.md'
 
 <CheckToolchain/>
 
-### Add credentials to sample
+## Add credentials to sample
 
 Navigate to the Golioth directory within Zephyr
 
@@ -44,7 +45,7 @@ CONFIG_GOLIOTH_SAMPLE_HARDCODED_PSK="DEVICE_PSK"
 ```
 Save and exit (`ctrl+x` in nano)
 
-### Build for a QEMU Device
+## Build for a QEMU Device
 
 At this point, you can build a Golioth Zephyr project:
 

--- a/docs/firmware/hardware/5-virtual-devices/2-zephyr-quickstart/5-simulating-devices-qemu.md
+++ b/docs/firmware/hardware/5-virtual-devices/2-zephyr-quickstart/5-simulating-devices-qemu.md
@@ -7,7 +7,7 @@ title: Simulating devices with QEMU
 
 import SetupZephyr from '/docs/_partials-common/zephyr-setup-dependencies.md'
 
-<SetupZephyr/>
+<SetupZephyr workspace_directory="golioth-zephyr-workspace"/>
 
 ### Install Golioth Firmware SDK
 

--- a/docs/getting-started/3-device-examples/2-compile-example-code/1-zephyr/01-set-up-zephyr.md
+++ b/docs/getting-started/3-device-examples/2-compile-example-code/1-zephyr/01-set-up-zephyr.md
@@ -1,5 +1,6 @@
 ---
 title: Set up Zephyr RTOS
+toc_max_heading_level: 2
 ---
 
 import Tabs from '@theme/Tabs';

--- a/docs/getting-started/3-device-examples/2-compile-example-code/2-zephyr-ncs/01-set-up-ncs.md
+++ b/docs/getting-started/3-device-examples/2-compile-example-code/2-zephyr-ncs/01-set-up-ncs.md
@@ -1,5 +1,6 @@
 ---
 title: Set up Nordic nRF Connect SDK (NCS)
+toc_max_heading_level: 2
 ---
 
 import Tabs from '@theme/Tabs';
@@ -15,19 +16,19 @@ Zephyr project.
 This section will guide you through installing NCS and the Zephyr tree
 (including the Golioth SDK) in a directory called `golioth-ncs-workspace`.
 
-### Install Dependencies and West
+## Install Dependencies and West
 
 import SetupWest from '/docs/_partials-common/zephyr-setup-dependencies.md'
 
 <SetupWest workspace_directory="golioth-ncs-workspace"/>
 
-### Installing the Golioth Firmware SDK for NCS
+## Install the Golioth Firmware SDK for NCS
 
 import InstallNRFSDK from '/docs/_partials-common/ncs-install-golioth-firmware-sdk.md'
 
 <InstallNRFSDK/>
 
-### Installing the Zephyr SDK Toolchain
+## Install the Zephyr SDK Toolchain
 
 Nordic chips are ARM-based device, so we will use the ARM toolchains (gcc, gdb,
 etc) included in the Zephyr SDK
@@ -36,7 +37,7 @@ import InstallZephyrSDKtoolchain from '/docs/_partials-common/install-zephyr-sdk
 
 <InstallZephyrSDKtoolchain/>
 
-### Installing the Segger J-Link and nRF Command Line Tools
+## Install the Segger J-Link and nRF Command Line Tools
 
 Zephyr uses `nrfjprog` to flash Nordic targets using a hardware programmer like
 the Segger J-Link, or the debugger that is built into the development kit (DK)


### PR DESCRIPTION
# Fix workspace directory name

If the workspace directory param is not specified when calling the partial, the workspace directory will render as `undefined`.

## Before

![image](https://github.com/user-attachments/assets/6701679b-05ee-42f7-be03-705e74bf143c)

## After

![image](https://github.com/user-attachments/assets/b143582c-c745-4bca-9148-36705d1474fb)

# Fix duplicate hedings in ToC sidebar

Headings in tabs being rendered multiple times. Limit ToC heading depth for these pages.

## Before

![image](https://github.com/user-attachments/assets/02bdb8b3-3ec3-4618-bdc1-648f61a1f704)

## After

![image](https://github.com/user-attachments/assets/a82c8102-115f-48f3-9935-132f39a76340)
