### PR TITLE
fix how management API section accesses process.env

### DIFF
--- a/docs/reference/3-management-api/2-openapi.md
+++ b/docs/reference/3-management-api/2-openapi.md
@@ -10,7 +10,9 @@ import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import BrowserOnly from "@docusaurus/BrowserOnly";
 
 export const APIDocs = () => {
-  const swaggerUrl = process.env.SWAGGER_URL;
+  const { siteConfig } = useDocusaurusContext();
+  const swaggerUrl =
+    siteConfig.customFields.swaggerUrl || "https://api.golioth.io/swagger.json";
   return (
     <div
       style={{

--- a/docs/reference/3-management-api/README.md
+++ b/docs/reference/3-management-api/README.md
@@ -4,12 +4,16 @@ title: Management API
 
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 export const SwaggerUrl = () => {
-  const swaggerUrl = process.env.SWAGGER_URL;
+  const { siteConfig } = useDocusaurusContext();
+  const swaggerUrl =
+    siteConfig.customFields.swaggerUrl || "https://api.golioth.io/swagger.json";
   return <a href={swaggerUrl}>Swagger / OpenAPI v2</a>;
 };
 
 export const OpenAPIUrl = () => {
-  const openAPIUrl = process.env.OPENAPI_URL;
+  const { siteConfig } = useDocusaurusContext();
+  const openAPIUrl =
+    siteConfig.customFields.openApiUrl || "https://api.golioth.io/openapi.json";
   return <a href={openAPIUrl}>OpenAPI v3</a>;
 };
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -12,6 +12,10 @@ module.exports = {
   favicon: "img/favicon.ico",
   organizationName: "golioth", // Usually your GitHub org/user name.
   projectName: "docs", // Usually your repo name.
+  customFields: {
+    swaggerUrl: process.env.SWAGGER_URL || "https://api.golioth.io/swagger.json",
+    openApiUrl: process.env.OPENAPI_URL || "https://api.golioth.io/openapi.json",
+  },
   themeConfig: {
     announcementBar: {
       id: 'canonical-announcement', // Any string id that represents this message


### PR DESCRIPTION
After we removed docusaurus2-dotenv, the management API pages would crash trying to access process.env.*. Use a custom field to inject process.env at runtime so process.env.SWAGGER_URL and process.env.OPENAPI_URL are available.