### PR TITLE
Fix robots.txt

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://docs.golioth.io/sitemap.xml


### PR DESCRIPTION
Adds robots.txt under the static directory so docs.golioth.io/robots.txt resolves as a text file instead of serving the SPA 404 HTML page. Points to the sitemap at https://docs.golioth.io/sitemap.xml.